### PR TITLE
read the gtfs only once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "gtfs-structures"
 version = "0.8.0"
-source = "git+https://github.com/rust-transit/gtfs-structure.git?branch=sync#ead8479de92350965c94d7d4ab7a0bd443f2ab42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1787,7 +1787,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gtfs-structures 0.8.0 (git+https://github.com/rust-transit/gtfs-structure.git?branch=sync)",
+ "gtfs-structures 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2125,7 +2125,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum gtfs-structures 0.8.0 (git+https://github.com/rust-transit/gtfs-structure.git?branch=sync)" = "<none>"
+"checksum gtfs-structures 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed5b46885fc34164dd73a48b9bacba39b3669f734dcf0fae49a12031705bfc47"
 "checksum h2 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7dd33bafe2e6370e6c8eb0cf1b8c5f93390b90acde7e9b03723f166b28b648ed"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,8 +619,8 @@ dependencies = [
 
 [[package]]
 name = "gtfs-structures"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.8.0"
+source = "git+https://github.com/rust-transit/gtfs-structure.git?branch=sync#ead8479de92350965c94d7d4ab7a0bd443f2ab42"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1787,7 +1787,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gtfs-structures 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gtfs-structures 0.8.0 (git+https://github.com/rust-transit/gtfs-structure.git?branch=sync)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2125,7 +2125,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum gtfs-structures 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db873adca82767911a70c1cfcda0b0feb4b3a4e2131a6ccae024157e36f84397"
+"checksum gtfs-structures 0.8.0 (git+https://github.com/rust-transit/gtfs-structure.git?branch=sync)" = "<none>"
 "checksum h2 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7dd33bafe2e6370e6c8eb0cf1b8c5f93390b90acde7e9b03723f166b28b648ed"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ prost = "0.4"
 prost-derive = "0.4"
 serde = "1.0"
 serde_derive = "1"
-# gtfs-structures = "0.6"
-gtfs-structures = { git = "https://github.com/rust-transit/gtfs-structure.git", version = "0.8", branch = "sync" }
+gtfs-structures = "0.8"
 structopt = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ prost = "0.4"
 prost-derive = "0.4"
 serde = "1.0"
 serde_derive = "1"
-gtfs-structures = "0.6"
+# gtfs-structures = "0.6"
+gtfs-structures = { git = "https://github.com/rust-transit/gtfs-structure.git", version = "0.8", branch = "sync" }
 structopt = "0.2"
 
 [dev-dependencies]

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,11 +11,16 @@ pub struct GtfsRT {
     pub data: Vec<u8>,
 }
 
+pub struct Data {
+    pub gtfs: gtfs_structures::Gtfs,
+    pub lines_of_stops: HashMap<String, HashSet<String>>,
+}
+
+#[derive(Clone)]
 pub struct Context {
     pub gtfs_rt: Arc<Mutex<Option<GtfsRT>>>,
-    pub gtfs: gtfs_structures::Gtfs,
+    pub data: Arc<Mutex<Data>>,
     pub gtfs_rt_provider_url: String,
-    pub lines_of_stops: HashMap<String, HashSet<String>>,
 }
 
 fn trip_has_stop(trip: &gtfs_structures::Trip, stop: &gtfs_structures::Stop) -> bool {
@@ -25,13 +30,23 @@ fn trip_has_stop(trip: &gtfs_structures::Trip, stop: &gtfs_structures::Stop) -> 
     })
 }
 
-pub fn lines_of_stop(
-    gtfs: &gtfs_structures::Gtfs,
-    stop: &gtfs_structures::Stop,
-) -> HashSet<String> {
+fn lines_of_stop(gtfs: &gtfs_structures::Gtfs, stop: &gtfs_structures::Stop) -> HashSet<String> {
     gtfs.trips
         .values()
         .filter(|trip| trip_has_stop(trip, stop))
         .map(|trip| trip.route_id.to_owned())
         .collect()
+}
+
+impl Data {
+    pub fn new(gtfs: gtfs_structures::Gtfs) -> Self {
+        Self {
+            lines_of_stops: gtfs
+                .stops
+                .values()
+                .map(|stop| (stop.id.to_owned(), lines_of_stop(&gtfs, stop)))
+                .collect(),
+            gtfs,
+        }
+    }
 }

--- a/src/gtfs_rt.rs
+++ b/src/gtfs_rt.rs
@@ -1,9 +1,9 @@
+use crate::context::{Context, GtfsRT};
+use crate::transit_realtime;
 use actix_web::http::{ContentEncoding, StatusCode};
 use actix_web::{error, HttpRequest, HttpResponse, Json, Result};
 use bytes::IntoBuf;
 use chrono::Utc;
-use crate::context::{Context, GtfsRT};
-use crate::transit_realtime;
 use failure::Error;
 use prost::Message;
 use reqwest;
@@ -65,7 +65,8 @@ pub fn gtfs_rt_json(req: &HttpRequest<Context>) -> Result<Json<transit_realtime:
                     e
                 ))
             })
-        }).ok_or_else(|| error::ErrorInternalServerError("impossible to access stored data"))?;
+        })
+        .ok_or_else(|| error::ErrorInternalServerError("impossible to access stored data"))?;
 
     Ok(Json(data?))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,8 @@ fn main() {
     let sys = actix::System::new("transpo-rt");
     let params = Params::from_args();
     let bind = format!("{}:{}", &params.bind, &params.port);
-    server::new(move || transpo_rt::server::create_server(&params.gtfs, &params.url))
+    let context = transpo_rt::server::make_context(&params.gtfs, &params.url);
+    server::new(move || transpo_rt::server::create_server(context.clone()))
         .bind(bind)
         .unwrap()
         .start();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,14 @@ struct Params {
         short = "g",
         long = "gtfs",
         help = "path or url to the GTFS zip",
-        env = "TRANSPO_RT_GTFS",
+        env = "TRANSPO_RT_GTFS"
     )]
     gtfs: String,
     #[structopt(
         short = "u",
         long = "url",
         help = "URL to the GTFS-RT provider",
-        env = "TRANSPO_RT_GTFS_RT_URL",
+        env = "TRANSPO_RT_GTFS_RT_URL"
     )]
     url: String,
     #[structopt(
@@ -32,7 +32,7 @@ struct Params {
         long = "port",
         help = "Port to listen to",
         env = "TRANSPO_RT_PORT",
-        default_value = "8080",
+        default_value = "8080"
     )]
     port: usize,
     #[structopt(
@@ -40,7 +40,7 @@ struct Params {
         long = "bind",
         help = "Bind adress",
         env = "TRANSPO_RT_BIND",
-        default_value = "0.0.0.0",
+        default_value = "0.0.0.0"
     )]
     bind: String,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,8 +1,8 @@
-use actix_web::{middleware, App};
 use crate::context::{Context, Data};
 use crate::gtfs_rt::{gtfs_rt, gtfs_rt_json};
 use crate::stop_monitoring::stop_monitoring;
 use crate::stoppoints_discovery::stoppoints_discovery;
+use actix_web::{middleware, App};
 use std::sync::{Arc, Mutex};
 
 pub fn make_context(gtfs: &str, url: &str) -> Context {
@@ -28,5 +28,6 @@ pub fn create_server(context: Context) -> App<Context> {
         .resource("/gtfs_rt.json", |r| r.f(gtfs_rt_json))
         .resource("/stoppoints_discovery.json", |r| {
             r.with(stoppoints_discovery)
-        }).resource("/stop_monitoring.json", |r| r.with(stop_monitoring))
+        })
+        .resource("/stop_monitoring.json", |r| r.with(stop_monitoring))
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,31 +1,32 @@
 use actix_web::{middleware, App};
-use crate::context::{lines_of_stop, Context};
+use crate::context::{Context, Data};
 use crate::gtfs_rt::{gtfs_rt, gtfs_rt_json};
 use crate::stop_monitoring::stop_monitoring;
 use crate::stoppoints_discovery::stoppoints_discovery;
 use std::sync::{Arc, Mutex};
 
-pub fn create_server(gtfs: &str, url: &str) -> App<Context> {
+pub fn make_context(gtfs: &str, url: &str) -> Context {
     let gtfs_rt_data = Arc::new(Mutex::new(None));
     let gtfs = if gtfs.starts_with("http") {
         gtfs_structures::Gtfs::from_url(gtfs).unwrap()
     } else {
         gtfs_structures::Gtfs::from_zip(gtfs).unwrap()
     };
-
-    App::with_state(Context {
+    let data = Data::new(gtfs);
+    let data = Arc::new(Mutex::new(data));
+    Context {
         gtfs_rt: gtfs_rt_data.clone(),
-        lines_of_stops: gtfs
-            .stops
-            .values()
-            .map(|stop| (stop.id.to_owned(), lines_of_stop(&gtfs, stop)))
-            .collect(),
-        gtfs,
+        data: data.clone(),
         gtfs_rt_provider_url: url.to_owned(),
-    }).middleware(middleware::Logger::default())
-    .resource("/gtfs_rt", |r| r.f(gtfs_rt))
-    .resource("/gtfs_rt.json", |r| r.f(gtfs_rt_json))
-    .resource("/stoppoints_discovery.json", |r| {
-        r.with(stoppoints_discovery)
-    }).resource("/stop_monitoring.json", |r| r.with(stop_monitoring))
+    }
+}
+
+pub fn create_server(context: Context) -> App<Context> {
+    App::with_state(context)
+        .middleware(middleware::Logger::default())
+        .resource("/gtfs_rt", |r| r.f(gtfs_rt))
+        .resource("/gtfs_rt.json", |r| r.f(gtfs_rt_json))
+        .resource("/stoppoints_discovery.json", |r| {
+            r.with(stoppoints_discovery)
+        }).resource("/stop_monitoring.json", |r| r.with(stop_monitoring))
 }

--- a/src/siri_model.rs
+++ b/src/siri_model.rs
@@ -1,4 +1,4 @@
-use crate::context::Context;
+use crate::context::Data;
 
 // TODO store a real date, and only change serialization
 #[derive(Debug, Serialize, Deserialize)]
@@ -119,8 +119,8 @@ pub struct SiriResponse {
 }
 
 impl AnnotatedStopPoint {
-    pub fn from(stop: &gtfs_structures::Stop, context: &Context) -> Self {
-        let lines = context
+    pub fn from(stop: &gtfs_structures::Stop, data: &Data) -> Self {
+        let lines = data
             .lines_of_stops
             .get(&stop.id)
             .unwrap_or(&std::collections::HashSet::new())

--- a/src/siri_model.rs
+++ b/src/siri_model.rs
@@ -127,7 +127,8 @@ impl AnnotatedStopPoint {
             .iter()
             .map(|route_id| Line {
                 line_ref: route_id.to_owned(),
-            }).collect();
+            })
+            .collect();
 
         Self {
             stop_point_ref: stop.id.to_owned(),

--- a/src/stop_monitoring.rs
+++ b/src/stop_monitoring.rs
@@ -1,7 +1,7 @@
-use actix_web::{error, Json, Query, Result, State};
-use chrono::Timelike;
 use crate::context::{Context, Data};
 use crate::siri_model as model;
+use actix_web::{error, Json, Query, Result, State};
+use chrono::Timelike;
 use gtfs_structures;
 use serde;
 use std::sync::Arc;
@@ -113,7 +113,8 @@ fn create_stop_monitoring(
             .filter(|stop_time| {
                 let stop_id = &stop_time.stop.id;
                 stop_id == &stop.id || stop.parent_station.as_ref() == Some(stop_id)
-            }).filter(|stop_time| keep_stop_time(&stop_time, request))
+            })
+            .filter(|stop_time| keep_stop_time(&stop_time, request))
         // TODO filter on departure after request.start_time
         // TODO filter on the other request's param (PreviewInterval, MaximumStopVisits)
         {

--- a/src/stoppoints_discovery.rs
+++ b/src/stoppoints_discovery.rs
@@ -1,5 +1,5 @@
-use actix_web::{Json, Query, Result, State};
 use crate::context::Context;
+use actix_web::{Json, Query, Result, State};
 use gtfs_structures;
 use siri_model::{AnnotatedStopPoint, Siri, SiriResponse, StopPointsDelivery};
 use std::borrow::Borrow;

--- a/src/stoppoints_discovery.rs
+++ b/src/stoppoints_discovery.rs
@@ -37,7 +37,10 @@ fn bounding_box_matches(
 pub fn stoppoints_discovery(
     (state, query): (State<Context>, Query<Params>),
 ) -> Result<Json<SiriResponse>> {
-    let stops = &state.gtfs.stops;
+    let arc_data = state.data.clone();
+
+    let data = arc_data.lock().unwrap();
+    let stops = &data.gtfs.stops;
 
     let request = query.into_inner();
     let q = request.q.unwrap_or_default().to_lowercase();
@@ -50,7 +53,7 @@ pub fn stoppoints_discovery(
         .values()
         .filter(|s| name_matches(s, &q))
         .filter(|s| bounding_box_matches(s, min_lon, max_lon, min_lat, max_lat))
-        .map(|stop| AnnotatedStopPoint::from(stop.borrow(), &state))
+        .map(|stop| AnnotatedStopPoint::from(stop.borrow(), &data))
         .collect();
 
     Ok(Json(SiriResponse {

--- a/tests/stop_point_discovery_test.rs
+++ b/tests/stop_point_discovery_test.rs
@@ -8,7 +8,9 @@ use transpo_rt::siri_model::SiriResponse;
 
 #[test]
 fn sp_discovery_integration_test() {
-    let make_server = || transpo_rt::server::create_server("fixtures/gtfs.zip", "");
+    let make_server = || {
+        transpo_rt::server::create_server(transpo_rt::server::make_context("fixtures/gtfs.zip", ""))
+    };
 
     let mut srv = TestServer::with_factory(make_server);
 


### PR DESCRIPTION
move the gtfs raw structures + computed ressources to a `Data` container
(I couldn't find a less meaningfull name, sorry...)

wrap all this in Arc<Mutex> to share it between the threads

Note: It depends on https://github.com/rust-transit/gtfs-structure/pull/8, and will need to be updated after the merge 