### PR TITLE
New shot at the actor model.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,3 @@
-use actix::Actor;
-use actix::AsyncContext;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use chrono_tz::Tz;
 use log::info;
@@ -66,30 +64,11 @@ pub struct FeedConstructionInfo {
     pub generation_period: Period,
 }
 
-pub struct Context {
+pub struct Dataset {
     pub gtfs_rt: Mutex<Option<GtfsRT>>,
     pub gtfs_rt_provider_url: String,
     pub data: Mutex<Data>,
     pub feed_construction_info: FeedConstructionInfo,
-}
-
-impl Actor for Context {
-    type Context = actix::Context<Self>;
-
-    fn started(&mut self, ctx: &mut Self::Context) {
-        info!("Starting the context actor");
-
-        // we refresh the data every 24h hours
-        ctx.run_interval(std::time::Duration::from_secs(60 * 60 * 24), |act, _ctx| {
-            info!("Updating the gtfs data");
-            let data = Data::from_path(
-                &act.feed_construction_info.feed_path,
-                &act.feed_construction_info.generation_period,
-            );
-            *act.data.lock().unwrap() = data;
-            info!("Data updated");
-        });
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/dataset_handler_actor.rs
+++ b/src/dataset_handler_actor.rs
@@ -1,0 +1,33 @@
+use crate::context::Dataset;
+use log::info;
+use std::sync::Arc;
+
+/// Actor whose role is to:
+///  * give a pointer to a Dataset (on the GetDataset Message)
+///  * update the pointer to a new Dataset (on the UpdateBaseSchedule Message)
+pub struct DatasetActor {
+    pub gtfs: Arc<Dataset>,
+    // pub real_time: Arc<RealTimeInfo>, // realtimeinfo = gtfs-rt + timetable ?
+}
+
+impl actix::Actor for DatasetActor {
+    type Context = actix::Context<Self>;
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        info!("Starting the context actor");
+    }
+}
+
+pub struct GetDataset;
+
+impl actix::Message for GetDataset {
+    type Result = Result<Arc<Dataset>, actix_web::Error>;
+}
+
+impl actix::Handler<GetDataset> for DatasetActor {
+    type Result = Result<Arc<Dataset>, actix_web::Error>;
+
+    fn handle(&mut self, _params: GetDataset, _ctx: &mut actix::Context<Self>) -> Self::Result {
+        // we return a new Arc on the dataset
+        Ok(self.gtfs.clone())
+    }
+}

--- a/src/gtfs_rt_utils.rs
+++ b/src/gtfs_rt_utils.rs
@@ -1,4 +1,4 @@
-use crate::context::{Context, DatedVehicleJourney, GtfsRT};
+use crate::context::{Dataset, DatedVehicleJourney, GtfsRT};
 use crate::transit_realtime;
 use actix_web::Result;
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -32,12 +32,12 @@ fn refresh_needed(previous: &Option<GtfsRT>) -> bool {
         .unwrap_or(true)
 }
 
-pub fn update_gtfs_rt(context: &Context) -> Result<()> {
+pub fn update_gtfs_rt(context: &Dataset) -> Result<()> {
     let _guard = get_gtfs_rt(context)?;
     Ok(())
 }
 
-pub fn get_gtfs_rt(context: &Context) -> Result<MutexGuard<Option<GtfsRT>>> {
+pub fn get_gtfs_rt(context: &Dataset) -> Result<MutexGuard<Option<GtfsRT>>> {
     let mut saved_data = context.gtfs_rt.lock().unwrap();
     if refresh_needed(&saved_data) {
         *saved_data = Some(GtfsRT {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod transit_realtime {
 pub(crate) mod utils;
 
 pub mod context;
+pub mod dataset_handler_actor;
 pub mod gtfs_rt;
 pub(crate) mod gtfs_rt_utils;
 pub mod server;
@@ -17,3 +18,4 @@ pub mod siri_model;
 pub(crate) mod status;
 pub mod stop_monitoring;
 pub mod stoppoints_discovery;
+pub mod update_actors;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,5 @@
-use crate::context::{Context, Data, FeedConstructionInfo, Period};
+use crate::context::{Data, Dataset, FeedConstructionInfo, Period};
+use crate::dataset_handler_actor::DatasetActor;
 use crate::gtfs_rt::{gtfs_rt, gtfs_rt_json};
 use crate::status::status_query;
 use crate::stop_monitoring::stop_monitoring_query;
@@ -7,9 +8,30 @@ use actix::Addr;
 use actix_web::{middleware, App};
 use std::sync::Mutex;
 
-pub fn make_context(gtfs: &str, url: &str, generation_period: &Period) -> Context {
+#[derive(Deserialize, Debug)]
+pub struct DatasetToLoad {
+    pub name: String,
+    pub id: String,
+    pub gtfs: String,
+    pub gtfs_rt: String,
+}
+
+impl DatasetToLoad {
+    pub fn new_default(gtfs: &str, gtfs_rt: &str) -> Self {
+        Self {
+            id: "default".into(),
+            name: "default".into(),
+            gtfs: gtfs.to_owned(),
+            gtfs_rt: gtfs_rt.to_owned(),
+        }
+    }
+}
+
+pub fn make_dataset(dataset: &DatasetToLoad, generation_period: &Period) -> Dataset {
+    let gtfs = &dataset.gtfs;
+    let url = &dataset.gtfs_rt;
     let data = Data::from_path(gtfs, generation_period);
-    Context {
+    Dataset {
         gtfs_rt: Mutex::new(None),
         data: Mutex::new(data),
         gtfs_rt_provider_url: url.to_owned(),
@@ -20,7 +42,7 @@ pub fn make_context(gtfs: &str, url: &str, generation_period: &Period) -> Contex
     }
 }
 
-pub fn create_server(addr: Addr<Context>) -> App<Addr<Context>> {
+pub fn create_server(addr: Addr<DatasetActor>) -> App<Addr<DatasetActor>> {
     App::with_state(addr)
         .middleware(middleware::Logger::default())
         .resource("/status", |r| r.f(status_query))

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,9 +1,7 @@
-use crate::context::Context;
-use actix::{Addr, Handler};
-use actix_web::{AsyncResponder, Error, HttpRequest, Json, Result};
+use crate::dataset_handler_actor::{DatasetActor, GetDataset};
+use actix::Addr;
+use actix_web::{AsyncResponder, Error, HttpRequest, Json};
 use futures::future::Future;
-
-struct Params;
 
 #[derive(Serialize, Debug)]
 pub struct Status {
@@ -11,26 +9,19 @@ pub struct Status {
     loaded_at: chrono::DateTime<chrono::Utc>,
 }
 
-impl actix::Message for Params {
-    type Result = Result<Status>;
-}
-impl Handler<Params> for Context {
-    type Result = Result<Status>;
-
-    fn handle(&mut self, _params: Params, _ctx: &mut actix::Context<Self>) -> Self::Result {
-        Ok(Status {
-            feed: self.feed_construction_info.feed_path.clone(),
-            loaded_at: self.data.lock().unwrap().loaded_at,
-        })
-    }
-}
-
 pub fn status_query(
-    req: &HttpRequest<Addr<Context>>,
+    req: &HttpRequest<Addr<DatasetActor>>,
 ) -> Box<Future<Item = Json<Status>, Error = Error>> {
     req.state()
-        .send(Params {})
+        .send(GetDataset)
         .map_err(Error::from)
-        .and_then(|result| result.map(Json))
+        .and_then(|dataset| {
+            dataset.map(|d| {
+                Json(Status {
+                    feed: d.feed_construction_info.feed_path.clone(),
+                    loaded_at: d.data.lock().unwrap().loaded_at,
+                })
+            })
+        })
         .responder()
 }

--- a/src/update_actors.rs
+++ b/src/update_actors.rs
@@ -1,0 +1,66 @@
+use crate::context::{Data, Dataset, FeedConstructionInfo};
+use crate::dataset_handler_actor::DatasetActor;
+use actix::AsyncContext;
+use log::info;
+use std::sync::{Arc, Mutex};
+
+/// Actor that once in a while reload the BaseSchedule data (GTFS)
+/// and send them to the DatasetActor
+pub struct BaseScheduleReloader {
+    pub feed_construction_info: FeedConstructionInfo,
+
+    // Address of the DatasetActor to notify for the data reloading
+    // NOte: for the moment it's a single Actor,
+    // but if we have several instances of DatasetActor we could have a list of recipient here
+    pub dataset_actor: actix::Addr<DatasetActor>,
+}
+
+impl BaseScheduleReloader {
+    fn update_data(&self) {
+        let new_data = Data::from_path(
+            &self.feed_construction_info.feed_path,
+            &self.feed_construction_info.generation_period,
+        );
+
+        let new_dataset = Dataset {
+            gtfs_rt: Mutex::new(None),
+            data: Mutex::new(new_data),
+            gtfs_rt_provider_url: "TODO".to_owned(),
+            feed_construction_info: self.feed_construction_info.clone(),
+        };
+        // we send those data as a BaseScheduleReloader message, for the DatasetActor to load those new data
+        self.dataset_actor
+            .do_send(UpdateBaseSchedule(Arc::new(new_dataset)));
+    }
+}
+
+impl actix::Actor for BaseScheduleReloader {
+    type Context = actix::Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        info!("Starting the base schedule updater actor");
+        ctx.run_interval(std::time::Duration::from_secs(60 * 60 * 24), |act, _ctx| {
+            info!("reloading baseschedule data");
+            act.update_data();
+        });
+    }
+}
+
+/// Message send to a DatasetActor to update its baseschedule data
+struct UpdateBaseSchedule(Arc<Dataset>);
+
+impl actix::Message for UpdateBaseSchedule {
+    type Result = ();
+}
+
+impl actix::Handler<UpdateBaseSchedule> for DatasetActor {
+    type Result = ();
+
+    fn handle(
+        &mut self,
+        params: UpdateBaseSchedule,
+        _ctx: &mut actix::Context<Self>,
+    ) -> Self::Result {
+        self.gtfs = params.0;
+    }
+}


### PR DESCRIPTION
The problem with the current implementation is that all the work is done
by the `Context` (now called `Dataset` :wink:) Actor and thus all the
webservice has become mainly single threaded...

This PR introduces:
 * a `DatasetActor` whose only job is to give an Arc (a shared pointer) to
a `Dataset`
 * a `BaseScheduleReloader` Actor whose job is to periodically reload the
data, and send the newly created `Dataset` to the `DatasetActor` for
updating.

Since the `DatasetActor` works in its own thread, this way we'll be able
to remove all the `Mutex`, and still have a multithread service!

For the moment all the Arcs have not been removed, because we still need
the mutate the `Dataset` when receiving a gtfs-rt, but this will be
changed in another PR.

Do not hesitate if you have better ideas for the naming, I don't feel satisfied by the current one! 