### PR TITLE
Add more information in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,37 @@
 # transpo-rt
-Simple API for public transport realtime data
 
-## Building
+Simple API for public transport realtime data.
+
+This API reads a public transport base schedule (a [GTFS](http://gtfs.org/)) and some realtime data (for the moment in [GTFS_RT](https://developers.google.com/transit/gtfs-realtime/) to provide realtime feeds in [siri lite](http://www.normes-donnees-tc.org/format-dechange/donnees-temps-reel/).
+
+### Using
+
+A [hosted version](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/) of this API, with a dataset on [grenoble](https://fr.wikipedia.org/wiki/Grenoble), a french city (base chedule taken from [here](https://www.metromobilite.fr/data/Horaires/SEM-GTFS.zip), gtfs_rt taken from [here](https://data.metromobilite.fr/api/gtfs-rt/GAM/trip-update)).
+
+The API provides several routes:
+
+* `GET` `/gtfs_rt`: get the gtfs-rt as binary - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/gtfs_rt)
+* `GET` `/gtfs_rt.json`: get the gtfs-rt as json - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/gtfs_rt.json)
+* `GET` `/siri-lite/stop_monitoring.json`: get a siri-lite stop monitoring response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/siri-lite/stoppoints_discovery.json?q=mairie)
+* `GET` `/siri-lite/stoppoints_discovery.json`: get a siri-lite stoppoint discovery response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/siri-lite/stop_monitoring.json?MonitoringRef=4235)
+* `GET` `/status`: simple status on the api - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/status)
+
+#### API details
+
+##### /siri/stop_monitoring.json
+
+The API follow the [Siri-lite specification](http://www.chouette.mobi/irys/wp-content/uploads/20151023-Siri-Lite-Sp%C3%A9cification-Interfaces-V1.4.pdf) (documentation in french).
+
+TODO document supported parameters
+
+##### /siri/stoppoints_discovery.json
+
+The API follow the [Siri-lite specification](http://www.chouette.mobi/irys/wp-content/uploads/20151023-Siri-Lite-Sp%C3%A9cification-Interfaces-V1.4.pdf) (documentation in french).
+TODO document supported parameters
+
+## Developping
+
+### Building
 
 To build the api, you need an up to date Rust version:
 
@@ -20,14 +50,14 @@ Then you can build it:
 cargo build
 ```
 
-## Running
+### Running
 
 You can check the needed cli parameters with the `-h` option:
 ```
 cargo run --release -- -h
 ```
 
-## Developping
+### Testing
 
 You can run all the tests (unit test, integration, clippy and fmt) with:
 ```
@@ -35,3 +65,15 @@ make check
 ```
 
 It will save you some time for the code review and continous integration ;)
+
+## Architecture
+
+The API has been made with [actix-web](https://github.com/actix/actix-web). This makes it possible to have a multithreaded API with data reloading and realtime updates without dataraces (thanks to [rust](https://www.rust-lang.org/)), nor mutexes (thanks to the [actix](https://github.com/actix/actix) [actor model](https://en.wikipedia.org/wiki/Actor_model)).
+
+To achieve this there is an `Actor` in charge of the data (`DatasetActor`). The api workers query this actor to get the latest data. The `DatasetActor` does not return directly the data, but a `Arc` to them (a rust shared pointer).
+
+In the background, 2 actors are in charge of periodic data reloading:
+* `BaseScheduleReloader` reloads once in a while the baseschedule dataset
+* `RealTimeReloader` reloads frequently the realtime dataset
+
+Once the data (baseschedule or realtime) has been reloaded, it is send to the `DatasetActor` via a message. When the `DatasetActor` processes this message, it replaces it's `Arc` to this data, dropping the references. The API workers that have aquired an `Arc` to those data can continue their work on those data. The old data will be deleted when all workers have finished their work on them (thus noboby owns an `Arc` to those data anymore).

--- a/src/server.rs
+++ b/src/server.rs
@@ -63,6 +63,10 @@ pub fn create_server(addr: Addr<DatasetActor>) -> App<Addr<DatasetActor>> {
         .resource("/status", |r| r.f(status_query))
         .resource("/gtfs_rt", |r| r.f(gtfs_rt))
         .resource("/gtfs_rt.json", |r| r.f(gtfs_rt_json))
-        .resource("/stoppoints_discovery.json", |r| r.with(sp_discovery))
-        .resource("/stop_monitoring.json", |r| r.with(stop_monitoring_query))
+        .resource("/siri-lite/stoppoints_discovery.json", |r| {
+            r.with(sp_discovery)
+        })
+        .resource("/siri-lite/stop_monitoring.json", |r| {
+            r.with(stop_monitoring_query)
+        })
 }

--- a/tests/stop_monitoring_test.rs
+++ b/tests/stop_monitoring_test.rs
@@ -11,7 +11,7 @@ fn sp_monitoring_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
+            "/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
         )
         .finish()
         .unwrap();
@@ -120,7 +120,7 @@ fn sp_monitoring_relatime_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00",
+            "/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00",
         )
         .finish()
         .unwrap();

--- a/tests/stop_point_discovery_test.rs
+++ b/tests/stop_point_discovery_test.rs
@@ -10,7 +10,10 @@ fn sp_discovery_integration_test() {
     let mut srv = utils::make_test_server();
 
     let request = srv
-        .client(http::Method::GET, "/stoppoints_discovery.json?q=mai")
+        .client(
+            http::Method::GET,
+            "/siri-lite/stoppoints_discovery.json?q=mai",
+        )
         .finish()
         .unwrap();
     let response = srv.execute(request.send()).unwrap();


### PR DESCRIPTION
I think it is nice to add a bit more information in the readme.

I tried to:
* add some general context on the API
* list all the routes
* add a bit of details on the general architecture since we had several iteration on this.

when documenting the routes, I found that the siri lite routes were better when nested behind `/siri-lite`, so I changed this too

fixes #50 