### PR TITLE
Multi datasets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,11 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lock_api"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +1645,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2047,7 @@ dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2358,6 +2375,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "zip"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2486,7 @@ dependencies = [
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "21138fc6669f438ed7ae3559d5789a5f0ba32f28c1f0608d1e452b0bb06ee936"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
+"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
@@ -2548,6 +2574,7 @@ dependencies = [
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
 "checksum serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d48f9f99cd749a2de71d29da5f948de7f2764cc5a9d7f3c97e3514d4ee6eabf2"
+"checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum signal-hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8941ae94fa73d0f73b422774b3a40a7195cecd88d1c090f4b37ade7dc795ab66"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
@@ -2625,4 +2652,5 @@ dependencies = [
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum wkt 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1b8d9bd2fc1fb7f91289e593194d51cf5a13b807b6c1a22522b8b967d9a15bc7"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"
 "checksum zip 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "77ce0ceee93c995954a31f77903925a6a8bb094709445238e344f2107910e29e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_derive = "1"
 structopt = "0.2"
 navitia_model = { git = "https://github.com/CanalTP/navitia_model.git", rev = "724b1b3d77ce9871cb02ff87c2d78fe64b2b27c0" }
 chrono-tz = "0.5"
+serde_yaml = "0.8"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A [hosted version](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.i
 The API provides several routes:
 
 * `GET` `/datasets`: list the available datasets - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets)
-* `GET` `/datasets/{id}/gtfs_rt`: get the gtfs-rt as binary - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets/metromobilite/gtfs_rt)
-* `GET` `/datasets/{id}/gtfs_rt.json`: get the gtfs-rt as json - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets/metromobilite/gtfs_rt.json)
-* `GET` `/datasets/{id}/siri-lite/stop_monitoring.json`: get a siri-lite stop monitoring response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets/metromobilite/siri-lite/stoppoints_discovery.json?q=mairie)
-* `GET` `/datasets/{id}/siri-lite/stoppoints_discovery.json`: get a siri-lite stoppoint discovery response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets/metromobilite/siri-lite/stop_monitoring.json?MonitoringRef=4235)
-* `GET` `/datasets/{id}/status`: simple status on the dataset - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io//datasets/metromobilite/status)
+* `GET` `/{id}/gtfs_rt`: get the gtfs-rt as binary - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/gtfs_rt)
+* `GET` `/{id}/gtfs_rt.json`: get the gtfs-rt as json - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/gtfs_rt.json)
+* `GET` `/{id}/siri-lite/stop_monitoring.json`: get a siri-lite stop monitoring response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/siri-lite/stoppoints_discovery.json?q=mairie)
+* `GET` `/{id}/siri-lite/stoppoints_discovery.json`: get a siri-lite stoppoint discovery response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/siri-lite/stop_monitoring.json?MonitoringRef=4235)
+* `GET` `/{id}/status`: simple status on the dataset - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io//metromobilite/status)
 
 #### API details
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ This API reads a public transport base schedule (a [GTFS](http://gtfs.org/)) and
 
 ### Using
 
-A [hosted version](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/) of this API, with a dataset on [grenoble](https://fr.wikipedia.org/wiki/Grenoble), a french city (base chedule taken from [here](https://www.metromobilite.fr/data/Horaires/SEM-GTFS.zip), gtfs_rt taken from [here](https://data.metromobilite.fr/api/gtfs-rt/GAM/trip-update)).
+A [hosted version](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/) of this API, with some french datasets can be freely used.
 
 The API provides several routes:
 
-* `GET` `/gtfs_rt`: get the gtfs-rt as binary - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/gtfs_rt)
-* `GET` `/gtfs_rt.json`: get the gtfs-rt as json - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/gtfs_rt.json)
-* `GET` `/siri-lite/stop_monitoring.json`: get a siri-lite stop monitoring response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/siri-lite/stoppoints_discovery.json?q=mairie)
-* `GET` `/siri-lite/stoppoints_discovery.json`: get a siri-lite stoppoint discovery response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/siri-lite/stop_monitoring.json?MonitoringRef=4235)
-* `GET` `/status`: simple status on the api - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/status)
+* `GET` `/datasets`: list the available datasets - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets)
+* `GET` `/datasets/{id}/gtfs_rt`: get the gtfs-rt as binary - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets/metromobilite/gtfs_rt)
+* `GET` `/datasets/{id}/gtfs_rt.json`: get the gtfs-rt as json - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets/metromobilite/gtfs_rt.json)
+* `GET` `/datasets/{id}/siri-lite/stop_monitoring.json`: get a siri-lite stop monitoring response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets/metromobilite/siri-lite/stoppoints_discovery.json?q=mairie)
+* `GET` `/datasets/{id}/siri-lite/stoppoints_discovery.json`: get a siri-lite stoppoint discovery response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/datasets/metromobilite/siri-lite/stop_monitoring.json?MonitoringRef=4235)
+* `GET` `/datasets/{id}/status`: simple status on the dataset - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io//datasets/metromobilite/status)
 
 #### API details
 

--- a/beta_gouv_datasets.yml
+++ b/beta_gouv_datasets.yml
@@ -1,0 +1,10 @@
+datasets:
+  - id: metromobilite
+    name: Grenoble
+    gtfs: https://www.metromobilite.fr/data/Horaires/SEM-GTFS.zip
+    gtfs-rt: https://data.metromobilite.fr/api/gtfs-rt/GAM/trip-update
+
+  - id: poitiers
+    name: Poitiers
+    gtfs: https://data.grandpoitiers.fr/api/v2/catalog/datasets/mobilite-arret-services-theoriques-bus-hiver/files/400d7da94eaacb5e52c612f8ac28e420
+    gtfs-rt: https://app.mecatran.com/utw/ws/gtfsfeed/realtime/poitiers?apiKey=5f60015b5c16355371622b3c70770c6736384c02

--- a/src/context.rs
+++ b/src/context.rs
@@ -103,6 +103,31 @@ impl Period {
     }
 }
 
+#[derive(Deserialize, Clone)]
+pub struct Datasets {
+    pub datasets: Vec<DatasetInfo>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct DatasetInfo {
+    pub name: String,
+    pub id: String,
+    pub gtfs: String,
+    pub gtfs_rt: String,
+}
+
+impl DatasetInfo {
+    pub fn new_default(gtfs: &str, gtfs_rt: &str) -> Self {
+        Self {
+            id: "default".into(),
+            name: "default name".into(),
+            gtfs: gtfs.to_owned(),
+            gtfs_rt: gtfs_rt.to_owned(),
+        }
+    }
+}
+
 // create a dt from a Date and a StopTime's time
 // Note: the time might be on the next day, for example "26:00:00"
 // is the next day at 2 in the morning

--- a/src/gtfs_rt_utils.rs
+++ b/src/gtfs_rt_utils.rs
@@ -6,7 +6,6 @@ use failure::Error;
 use log::{debug, trace, warn};
 use navitia_model::collection::Idx;
 use navitia_model::objects::StopPoint;
-use reqwest;
 use std::collections::HashMap;
 
 pub struct StopTimeUpdate {

--- a/src/routes/datasets.rs
+++ b/src/routes/datasets.rs
@@ -1,0 +1,7 @@
+use crate::context::{DatasetInfo, Datasets};
+use actix_web::{HttpRequest, Json};
+
+/// Api to list all the hosted datasets
+pub fn list_datasets(req: &HttpRequest<Datasets>) -> Json<Vec<DatasetInfo>> {
+    Json(req.state().datasets.clone())
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,8 +1,10 @@
+mod datasets;
 mod gtfs_rt;
 mod status;
 mod stop_monitoring;
 mod stoppoints_discovery;
 
+pub use self::datasets::list_datasets;
 pub use self::gtfs_rt::{gtfs_rt, gtfs_rt_json};
 pub use self::status::status_query;
 pub use self::stop_monitoring::stop_monitoring_query;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,34 +1,19 @@
 use crate::actors::{BaseScheduleReloader, DatasetActor, RealTimeReloader};
 use crate::context;
-use crate::context::{Dataset, Period};
-use crate::routes::{gtfs_rt, gtfs_rt_json, sp_discovery, status_query, stop_monitoring_query};
+use crate::context::{Dataset, DatasetInfo, Datasets, Period};
+use crate::routes::{
+    gtfs_rt, gtfs_rt_json, list_datasets, sp_discovery, status_query, stop_monitoring_query,
+};
 use actix::Actor;
 use actix::Addr;
 use actix_web::middleware::cors::Cors;
+use actix_web::server::{HttpHandler, HttpHandlerTask};
 use actix_web::{middleware, App};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
-#[derive(Deserialize, Debug)]
-pub struct DatasetToLoad {
-    pub name: String,
-    pub id: String,
-    pub gtfs: String,
-    pub gtfs_rt: String,
-}
-
-impl DatasetToLoad {
-    pub fn new_default(gtfs: &str, gtfs_rt: &str) -> Self {
-        Self {
-            id: "default".into(),
-            name: "default".into(),
-            gtfs: gtfs.to_owned(),
-            gtfs_rt: gtfs_rt.to_owned(),
-        }
-    }
-}
-
-pub fn create_all_actors(
-    dataset_info: &DatasetToLoad,
+pub fn create_dataset_actors(
+    dataset_info: &DatasetInfo,
     generation_period: &Period,
 ) -> Addr<DatasetActor> {
     let dataset = Dataset::from_path(&dataset_info.gtfs, &generation_period);
@@ -56,17 +41,53 @@ pub fn create_all_actors(
     dataset_actors_addr
 }
 
-pub fn create_server(addr: Addr<DatasetActor>) -> App<Addr<DatasetActor>> {
-    App::with_state(addr)
-        .middleware(middleware::Logger::default())
-        .middleware(Cors::build().allowed_methods(vec!["GET"]).finish())
-        .resource("/status", |r| r.f(status_query))
-        .resource("/gtfs_rt", |r| r.f(gtfs_rt))
-        .resource("/gtfs_rt.json", |r| r.f(gtfs_rt_json))
-        .resource("/siri-lite/stoppoints_discovery.json", |r| {
-            r.with(sp_discovery)
+pub fn create_all_actors(
+    datasets: &Datasets,
+    generation_period: &Period,
+) -> BTreeMap<String, Addr<DatasetActor>> {
+    datasets
+        .datasets
+        .iter()
+        .map(|d| (d.id.clone(), create_dataset_actors(&d, generation_period)))
+        .collect()
+}
+
+pub fn create_datasets_servers(
+    datasets_actors: &BTreeMap<String, Addr<DatasetActor>>,
+) -> Vec<App<Addr<DatasetActor>>> {
+    datasets_actors
+        .iter()
+        .map(|(id, a)| {
+            App::with_state(a.clone())
+                .prefix(format!("/datasets/{id}", id = &id))
+                .middleware(middleware::Logger::default())
+                .middleware(Cors::build().allowed_methods(vec!["GET"]).finish())
+                .resource("/status", |r| r.f(status_query))
+                .resource("/gtfs_rt", |r| r.f(gtfs_rt))
+                .resource("/gtfs_rt.json", |r| r.f(gtfs_rt_json))
+                .resource("/siri-lite/stoppoints_discovery.json", |r| {
+                    r.with(sp_discovery)
+                })
+                .resource("/siri-lite/stop_monitoring.json", |r| {
+                    r.with(stop_monitoring_query)
+                })
         })
-        .resource("/siri-lite/stop_monitoring.json", |r| {
-            r.with(stop_monitoring_query)
-        })
+        .collect()
+}
+
+pub fn create_server(
+    datasets_actors: &BTreeMap<String, Addr<DatasetActor>>,
+    datasets: &Datasets,
+) -> Vec<Box<dyn HttpHandler<Task = Box<dyn HttpHandlerTask>>>> {
+    create_datasets_servers(datasets_actors)
+        .into_iter()
+        .map(|s| s.boxed())
+        .chain(std::iter::once(
+            App::with_state(datasets.clone())
+                .middleware(middleware::Logger::default())
+                .middleware(Cors::build().allowed_methods(vec!["GET"]).finish())
+                .resource("/datasets", |r| r.f(list_datasets))
+                .boxed(),
+        ))
+        .collect()
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -59,7 +59,7 @@ pub fn create_datasets_servers(
         .iter()
         .map(|(id, a)| {
             App::with_state(a.clone())
-                .prefix(format!("/datasets/{id}", id = &id))
+                .prefix(format!("/{id}", id = &id))
                 .middleware(middleware::Logger::default())
                 .middleware(Cors::build().allowed_methods(vec!["GET"]).finish())
                 .resource("/status", |r| r.f(status_query))

--- a/tests/list_datasets_test.rs
+++ b/tests/list_datasets_test.rs
@@ -1,0 +1,26 @@
+use actix_web::http;
+use actix_web::HttpMessage;
+use transpo_rt::context::DatasetInfo;
+mod utils;
+
+#[test]
+fn list_datasets_integration_test() {
+    let mut srv = utils::make_test_server();
+
+    let request = srv.client(http::Method::GET, "/datasets").finish().unwrap();
+    let response = srv.execute(request.send()).unwrap();
+
+    assert!(response.status().is_success());
+
+    let bytes = srv.execute(response.body()).unwrap();
+    let body = std::str::from_utf8(&bytes).unwrap();
+
+    let datasets: Vec<DatasetInfo> = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(datasets.len(), 1);
+    let dataset = &datasets[0];
+    assert_eq!(dataset.id, "default");
+    assert_eq!(dataset.name, "default name");
+    assert_eq!(dataset.gtfs, "fixtures/gtfs.zip");
+    assert!(!dataset.gtfs_rt.is_empty());
+}

--- a/tests/stop_monitoring_test.rs
+++ b/tests/stop_monitoring_test.rs
@@ -11,7 +11,7 @@ fn sp_monitoring_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/datasets/default/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
+            "/default/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
         )
         .finish()
         .unwrap();
@@ -120,7 +120,7 @@ fn sp_monitoring_relatime_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/datasets/default/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00",
+            "/default/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00",
         )
         .finish()
         .unwrap();

--- a/tests/stop_monitoring_test.rs
+++ b/tests/stop_monitoring_test.rs
@@ -11,7 +11,7 @@ fn sp_monitoring_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
+            "/datasets/default/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
         )
         .finish()
         .unwrap();
@@ -120,7 +120,7 @@ fn sp_monitoring_relatime_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00",
+            "/datasets/default/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00",
         )
         .finish()
         .unwrap();

--- a/tests/stop_point_discovery_test.rs
+++ b/tests/stop_point_discovery_test.rs
@@ -12,7 +12,7 @@ fn sp_discovery_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/datasets/default/siri-lite/stoppoints_discovery.json?q=mai",
+            "/default/siri-lite/stoppoints_discovery.json?q=mai",
         )
         .finish()
         .unwrap();

--- a/tests/stop_point_discovery_test.rs
+++ b/tests/stop_point_discovery_test.rs
@@ -12,7 +12,7 @@ fn sp_discovery_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/siri-lite/stoppoints_discovery.json?q=mai",
+            "/datasets/default/siri-lite/stoppoints_discovery.json?q=mai",
         )
         .finish()
         .unwrap();

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,6 +1,7 @@
 use chrono::NaiveDate;
 use prost::Message;
 use std::sync::{Once, ONCE_INIT};
+use transpo_rt::context::{DatasetInfo, Datasets};
 
 static LOGGER_INIT: Once = ONCE_INIT;
 const SERVER_PATH: &str = "/gtfs_rt";
@@ -14,12 +15,14 @@ pub fn make_test_server() -> actix_web::test::TestServer {
     };
 
     let make_server = move || {
-        let dataset_infos = transpo_rt::server::DatasetToLoad::new_default(
-            "fixtures/gtfs.zip",
-            &(mockito::SERVER_URL.to_string() + SERVER_PATH),
-        );
+        let dataset_infos = Datasets {
+            datasets: vec![DatasetInfo::new_default(
+                "fixtures/gtfs.zip",
+                &(mockito::SERVER_URL.to_string() + SERVER_PATH),
+            )],
+        };
         let dataset_actors_addr = transpo_rt::server::create_all_actors(&dataset_infos, &period);
-        transpo_rt::server::create_server(dataset_actors_addr)
+        transpo_rt::server::create_server(&dataset_actors_addr, &dataset_infos)
     };
 
     actix_web::test::TestServer::with_factory(make_server)


### PR DESCRIPTION
enable the API to load multiple datasets

⚠️ this is a breaking API change ⚠️

now the Apis are nested in a `/datasets/{id}` path.

example:
`/datasets/metromobilite/siri-lite/stoppoints_discovery.json?q=mairie`

it also adds  `/datasets` route to have the list of the loaded datasets

The datasets are given in a yaml file. Our configuration is store in the
depository for ease of use.

Note: we have to update clever cloud after merging this PR
Note: I branched from #50 it would be better to merge it before (and review only the [last commit](https://github.com/etalab/transpo-rt/commit/249922d6367f223656c7d46d8b644fa5a71fcb69)) 