### PR TITLE
breaking change: change routes for siri coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ A [hosted version](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.i
 The API provides several routes:
 
 * `GET` `/`: list the available datasets - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/)
-* `GET` `/{id}/gtfs_rt`: get the gtfs-rt as binary - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/gtfs_rt)
-* `GET` `/{id}/gtfs_rt.json`: get the gtfs-rt as json - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/gtfs_rt.json)
-* `GET` `/{id}/siri-lite/stop_monitoring.json`: get a siri-lite stop monitoring response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/siri-lite/stoppoints_discovery.json?q=mairie)
-* `GET` `/{id}/siri-lite/stoppoints_discovery.json`: get a siri-lite stoppoint discovery response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/siri-lite/stop_monitoring.json?MonitoringRef=4235)
+* `GET` `/{id}/gtfs-rt`: get the gtfs-rt as binary - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/gtfs-rt)
+* `GET` `/{id}/gtfs-rt.json`: get the gtfs-rt as json - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/gtfs-rt.json)
+* `GET` `/{id}/siri/2.0/stop-monitoring.json`: get a siri-lite stop monitoring response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/siri/2.0/stoppoints-discovery.json?q=mairie)
+* `GET` `/{id}/siri/2.0/stoppoints-discovery.json`: get a siri-lite stoppoint discovery response - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/siri/2.0/stop-monitoring.json?MonitoringRef=4235)
 * `GET` `/{id}/`: simple status on the dataset - [example call](https://app-be8e53a7-9b77-4f95-bea0-681b97077017.cleverapps.io/metromobilite/)
 
 #### API details
 
-##### /siri/stop_monitoring.json
+##### /siri/2.0/stop-monitoring.json
 
 The API follow the [Siri-lite specification](http://www.chouette.mobi/irys/wp-content/uploads/20151023-Siri-Lite-Sp%C3%A9cification-Interfaces-V1.4.pdf) (documentation in french).
 
 TODO document supported parameters
 
-##### /siri/stoppoints_discovery.json
+##### /siri/2.0/stoppoints-discovery.json
 
 The API follow the [Siri-lite specification](http://www.chouette.mobi/irys/wp-content/uploads/20151023-Siri-Lite-Sp%C3%A9cification-Interfaces-V1.4.pdf) (documentation in french).
 TODO document supported parameters

--- a/src/server.rs
+++ b/src/server.rs
@@ -63,13 +63,12 @@ pub fn create_datasets_servers(
                 .middleware(middleware::Logger::default())
                 .middleware(Cors::build().allowed_methods(vec!["GET"]).finish())
                 .resource("/", |r| r.f(status_query))
-                .resource("/gtfs_rt", |r| r.f(gtfs_rt))
-                .resource("/gtfs_rt.json", |r| r.f(gtfs_rt_json))
-                .resource("/siri-lite/stoppoints_discovery.json", |r| {
-                    r.with(sp_discovery)
-                })
-                .resource("/siri-lite/stop_monitoring.json", |r| {
-                    r.with(stop_monitoring_query)
+                .resource("/gtfs-rt", |r| r.f(gtfs_rt))
+                .resource("/gtfs-rt.json", |r| r.f(gtfs_rt_json))
+                .scope("/siri/2.0/", |scope| {
+                    scope
+                        .resource("/stoppoints-discovery.json", |r| r.with(sp_discovery))
+                        .resource("/stop-monitoring.json", |r| r.with(stop_monitoring_query))
                 })
         })
         .collect()

--- a/tests/multiple_gtfs_rts.rs
+++ b/tests/multiple_gtfs_rts.rs
@@ -95,7 +95,7 @@ fn test_stop_monitoring(srv: &mut actix_web::test::TestServer) {
     let request = srv
         .client(
             http::Method::GET,
-            "/default/siri-lite/stop_monitoring.json?MonitoringRef=BEATTY_AIRPORT&StartTime=2018-12-15T05:22:00",
+            "/default/siri/2.0/stop-monitoring.json?MonitoringRef=BEATTY_AIRPORT&StartTime=2018-12-15T05:22:00",
         )
         .finish()
         .unwrap();
@@ -165,7 +165,7 @@ fn test_stop_monitoring(srv: &mut actix_web::test::TestServer) {
 
 fn test_gtfs_rt(srv: &mut actix_web::test::TestServer) {
     let request = srv
-        .client(http::Method::GET, "/default/gtfs_rt.json")
+        .client(http::Method::GET, "/default/gtfs-rt.json")
         .finish()
         .unwrap();
     let response = srv.execute(request.send()).unwrap();

--- a/tests/stop_monitoring_test.rs
+++ b/tests/stop_monitoring_test.rs
@@ -15,7 +15,7 @@ fn sp_monitoring_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/default/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
+            "/default/siri/2.0/stop-monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
         )
         .finish()
         .unwrap();
@@ -62,7 +62,7 @@ fn test_beatty_stop_call(srv: &mut actix_web::test::TestServer) {
     let request = srv
         .client(
             http::Method::GET,
-            "/default/siri-lite/stop_monitoring.json?MonitoringRef=BEATTY_AIRPORT&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
+            "/default/siri/2.0/stop-monitoring.json?MonitoringRef=BEATTY_AIRPORT&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled",
         )
         .finish()
         .unwrap();
@@ -125,7 +125,7 @@ fn test_beatty_stop_call(srv: &mut actix_web::test::TestServer) {
     let request = srv
         .client(
             http::Method::GET,
-            "/default/siri-lite/stop_monitoring.json?MonitoringRef=BEATTY_AIRPORT&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled&LineRef=AB",
+            "/default/siri/2.0/stop-monitoring.json?MonitoringRef=BEATTY_AIRPORT&StartTime=2018-12-15T05:22:00&DataFreshness=Scheduled&LineRef=AB",
         )
         .finish()
         .unwrap();
@@ -221,7 +221,7 @@ fn sp_monitoring_relatime_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/default/siri-lite/stop_monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00",
+            "/default/siri/2.0/stop-monitoring.json?MonitoringRef=EMSI&StartTime=2018-12-15T05:22:00",
         )
         .finish()
         .unwrap();

--- a/tests/stop_point_discovery_test.rs
+++ b/tests/stop_point_discovery_test.rs
@@ -12,7 +12,7 @@ fn sp_discovery_integration_test() {
     let request = srv
         .client(
             http::Method::GET,
-            "/default/siri-lite/stoppoints_discovery.json?q=mai",
+            "/default/siri/2.0/stoppoints-discovery.json?q=mai",
         )
         .finish()
         .unwrap();


### PR DESCRIPTION
the routes were not respecting the [siri specification](http://www.normes-donnees-tc.org/wp-content/uploads/2018/10/Proposition-Profil-SIRI-Lite-initial-v1-3.pdf)

This is a breaking change, but I think we don't have any user for the moment, so we should do this right now.

Change:
`/{id}/siri-lite/stop_monitoring.json` -> `/{id}/siri/2.0/stop-monitoring.json` 
(same for stoppoints-discovery)

also changed `/{id}/gtfs_rt` to `/{id}/gtfs-rt` for API coherence

fixes https://github.com/etalab/transpo-rt/issues/64

:warning: We need to update transport site after this is merged :warning: 