### PR TITLE
stop_id in stop_time_update is not mandatory

### DIFF
--- a/src/actors/realtime_update_actors.rs
+++ b/src/actors/realtime_update_actors.rs
@@ -91,14 +91,16 @@ fn apply_rt_update(
                 .get(&connection.sequence);
             if let Some(stop_time_update) = stop_time_update {
                 // integrity check
-                if stop_time_update.stop_point_idx != connection.stop_point_idx {
-                    log::warn!("for trip {}, invalid stop connection, the stop n.{} '{}' does not correspond to the gtfsrt stop '{}'",
+                if let Some(stop_idx) = stop_time_update.stop_point_idx {
+                    if stop_idx != connection.stop_point_idx {
+                        log::warn!("for trip {}, invalid stop connection, the stop n.{} '{}' does not correspond to the gtfsrt stop '{}'",
                     &data.ntm.vehicle_journeys[connection.dated_vj.vj_idx].id,
                     &connection.sequence,
                     &data.ntm.stop_points[connection.stop_point_idx].id,
-                    &data.ntm.stop_points[stop_time_update.stop_point_idx].id,
+                    &data.ntm.stop_points[stop_idx].id,
                     );
-                    continue;
+                        continue;
+                    }
                 }
                 updated_timetable.realtime_connections.insert(
                     idx,

--- a/src/tests/update_model_test.rs
+++ b/src/tests/update_model_test.rs
@@ -74,7 +74,7 @@ fn read_simple_gtfs_rt() {
     assert_eq!(
         stu[&2],
         model_update::StopTimeUpdate {
-            stop_point_idx: model.stop_points.get_idx("B").unwrap(),
+            stop_point_idx: model.stop_points.get_idx("B"),
             updated_arrival: Some(ndt("2018-12-15T11:00:30")),
             updated_departure: Some(ndt("2018-12-15T11:01:30")),
         }
@@ -82,7 +82,7 @@ fn read_simple_gtfs_rt() {
     assert_eq!(
         stu[&4],
         model_update::StopTimeUpdate {
-            stop_point_idx: model.stop_points.get_idx("D").unwrap(),
+            stop_point_idx: model.stop_points.get_idx("D"),
             updated_arrival: Some(ndt("2018-12-15T13:00:30")),
             updated_departure: Some(ndt("2018-12-15T13:01:30")),
         }
@@ -161,7 +161,7 @@ fn feed_on_unknown_stop_and_trip() {
     assert_eq!(
         stu[&2],
         model_update::StopTimeUpdate {
-            stop_point_idx: model.stop_points.get_idx("B").unwrap(),
+            stop_point_idx: model.stop_points.get_idx("B"),
             updated_arrival: Some(ndt("2018-12-15T11:00:30")),
             updated_departure: Some(ndt("2018-12-15T11:01:30")),
         }
@@ -169,7 +169,7 @@ fn feed_on_unknown_stop_and_trip() {
     assert_eq!(
         stu[&4],
         model_update::StopTimeUpdate {
-            stop_point_idx: model.stop_points.get_idx("D").unwrap(),
+            stop_point_idx: model.stop_points.get_idx("D"),
             updated_arrival: Some(ndt("2018-12-15T14:00:30")),
             updated_departure: None,
         }


### PR DESCRIPTION
stick a bit more to the gtfs_rt spec.

the stop_sequence is mandatory for the moment though, we'll check if some people do not give it