### PR TITLE
add basic sentry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derivative"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +633,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fragile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +737,11 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "humantime"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +795,15 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "im"
+version = "12.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1641,6 +1671,57 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "sentry"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httpdate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "im 12.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentry-actix"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "actix-web 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fragile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debugid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2183,8 @@ dependencies = [
  "prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-actix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2180,9 +2263,22 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ucd-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicase"
@@ -2261,6 +2357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "url_serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,6 +2376,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2500,6 +2606,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum csv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd1c44c58078cfbeaf11fbb3eac9ae5534c23004ed770cc4bfb48e658ae4f04"
 "checksum csv-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa5cdef62f37e6ffe7d1f07a381bc0db32b7a3ff1cac0de56cb0d81e71f53d65"
+"checksum debugid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb088ba9178f59386641547f9c22fd1d658e2d130f02359bb562759f8f992fc"
 "checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
@@ -2522,6 +2629,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fragile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f8140122fa0d5dcb9fc8627cfce2b37cc1500f752636d46ea28bc26785c2f9"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -2534,10 +2642,12 @@ dependencies = [
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1a10e5b573b9a0146545010f50772b9e8b1dd0a256564cc4307694c68832a2f5"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
+"checksum httpdate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.23 (registry+https://github.com/rust-lang/crates.io-index)" = "860faf61a9957c9cb0e23e69f1c8290e92f6eb660fcdd1f2d6777043a2ae1a46"
 "checksum hyper-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32cd73f14ad370d3b4d4b7dce08f69b81536c82e39fcc89731930fe5788cd661"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+"checksum im 12.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0627d417829c1d763d602687634869f254fc79f7e22dea6c824dab993db857e4"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "08f7eadeaf4b52700de180d147c4805f199854600b36faa963d91114827b2ffc"
@@ -2635,6 +2745,9 @@ dependencies = [
 "checksum security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d6696852716b589dff9e886ff83778bb635150168e83afa8ac6b8a78cb82abc"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum sentry 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b85d01c9f486937cf0972435475de7a8ad84e2f85201c7a1891ae70301d5f07"
+"checksum sentry-actix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd6259d4b7e0f265089a8b2092b485983e829df1ecbfb658f1a30d6945ea6d5e"
+"checksum sentry-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d4120ca636ad2934528f5fbceeb22a80f0c9160b0400136cb05fbaa37d5c484"
 "checksum serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "2e20fde37801e83c891a2dc4ebd3b81f0da4d1fb67a9e0a2a3b921e2536a58ee"
 "checksum serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "633e97856567e518b59ffb2ad7c7a4fd4c5d91d9c7f32dd38a27b2bf7e8114ea"
 "checksum serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "27dce848e7467aa0e2fcaf0a413641499c0b745452aaca1194d24dedde9e13c9"
@@ -2683,7 +2796,9 @@ dependencies = [
 "checksum trust-dns-proto 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "09144f0992b0870fa8d2972cc069cbf1e3c0fda64d1f3d45c4d68d0e0b52ad4e"
 "checksum trust-dns-resolver 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a9f877f7a1ad821ab350505e1f1b146a4960402991787191d6d8cab2ce2de2c"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
@@ -2695,6 +2810,7 @@ dependencies = [
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+"checksum url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0238db0c5b605dd1cf51de0f21766f97fba2645897024461d6a00c036819a768"
 "checksum v_escape 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c8b50688edb86f4c092a1a9fe8bda004b0faa3197100897653809e97e09a2814"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 [dependencies]
 actix = "0.7"
 actix-web = "0.7"
+sentry-actix = "0.13.0"
+sentry = "0.13.0"
 env_logger = "0.6"
 futures = "0.1"
 reqwest = "0.9"
@@ -27,8 +29,8 @@ time-parse = "0.1"
 [dev-dependencies]
 serde_json = "1.0"
 mockito = "0.15"
-maplit = "1.0"
 model-builder = { git = "https://github.com/CanalTP/navitia_model.git", rev = "dc094979edff9147041330fab58294c2026006ac" }
+maplit = "1.0"
 
 [build-dependencies]
 prost-build = "0.4"

--- a/src/actors/realtime_update_actors.rs
+++ b/src/actors/realtime_update_actors.rs
@@ -91,14 +91,16 @@ fn apply_rt_update(
                 .get(&connection.sequence);
             if let Some(stop_time_update) = stop_time_update {
                 // integrity check
-                if stop_time_update.stop_point_idx != connection.stop_point_idx {
-                    log::warn!("for trip {}, invalid stop connection, the stop n.{} '{}' does not correspond to the gtfsrt stop '{}'",
+                if let Some(stop_idx) = stop_time_update.stop_point_idx {
+                    if stop_idx != connection.stop_point_idx {
+                        log::warn!("for trip {}, invalid stop connection, the stop n.{} '{}' does not correspond to the gtfsrt stop '{}'",
                     &data.ntm.vehicle_journeys[connection.dated_vj.vj_idx].id,
                     &connection.sequence,
                     &data.ntm.stop_points[connection.stop_point_idx].id,
-                    &data.ntm.stop_points[stop_time_update.stop_point_idx].id,
+                    &data.ntm.stop_points[stop_idx].id,
                     );
-                    continue;
+                        continue;
+                    }
                 }
                 updated_timetable.realtime_connections.insert(
                     idx,

--- a/src/actors/update_actors.rs
+++ b/src/actors/update_actors.rs
@@ -18,6 +18,7 @@ pub struct BaseScheduleReloader {
 impl BaseScheduleReloader {
     fn update_data(&self) {
         let new_dataset = Dataset::from_path(
+            &self.feed_construction_info.id,
             &self.feed_construction_info.feed_path,
             &crate::datasets::Period {
                 begin: chrono::Local::today().naive_local(),

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -62,6 +62,7 @@ pub struct UpdatedTimetable {
 
 #[derive(Clone)]
 pub struct FeedConstructionInfo {
+    pub id: String,
     pub feed_path: String,
     pub generation_period: Period,
 }
@@ -203,7 +204,12 @@ impl HasTimezone for navitia_model::Model {
 }
 
 impl Dataset {
-    pub fn new(ntm: navitia_model::Model, gtfs_path: &str, generation_period: &Period) -> Self {
+    pub fn new(
+        id: &str,
+        ntm: navitia_model::Model,
+        gtfs_path: &str,
+        generation_period: &Period,
+    ) -> Self {
         // To correctly handle GTFS-RT stream we need the dataset's timezone,
         // as all the time in the dataset are in local time and the GTFS-RT gives its time
         // as UTC.
@@ -221,11 +227,12 @@ impl Dataset {
             feed_construction_info: FeedConstructionInfo {
                 feed_path: gtfs_path.to_owned(),
                 generation_period: generation_period.clone(),
+                id: id.to_owned(),
             },
         }
     }
 
-    pub fn from_path(gtfs: &str, generation_period: &Period) -> Self {
+    pub fn from_path(id: &str, gtfs: &str, generation_period: &Period) -> Self {
         log::info!("reading from path");
         let nav_data = if gtfs.starts_with("http") {
             navitia_model::gtfs::read_from_url(gtfs, None::<&str>, None).unwrap()
@@ -233,7 +240,7 @@ impl Dataset {
             navitia_model::gtfs::read_from_zip(gtfs, None::<&str>, None).unwrap()
         };
         log::info!("gtfs read");
-        Self::new(nav_data, gtfs, &generation_period)
+        Self::new(id, nav_data, gtfs, &generation_period)
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,7 +16,7 @@ pub fn create_dataset_actors(
     dataset_info: &DatasetInfo,
     generation_period: &Period,
 ) -> Addr<DatasetActor> {
-    let dataset = Dataset::from_path(&dataset_info.gtfs, &generation_period);
+    let dataset = Dataset::from_path(&dataset_info.id, &dataset_info.gtfs, &generation_period);
     let arc_dataset = Arc::new(dataset);
     let rt_dataset =
         datasets::RealTimeDataset::new(arc_dataset.clone(), &dataset_info.gtfs_rt_urls);
@@ -27,6 +27,7 @@ pub fn create_dataset_actors(
     let dataset_actors_addr = dataset_actors.start();
     let base_schedule_reloader = BaseScheduleReloader {
         feed_construction_info: datasets::FeedConstructionInfo {
+            id: dataset_info.id.clone(),
             feed_path: dataset_info.gtfs.clone(),
             generation_period: generation_period.clone(),
         },
@@ -34,6 +35,7 @@ pub fn create_dataset_actors(
     };
     base_schedule_reloader.start();
     let realtime_reloader = RealTimeReloader {
+        dataset_id: dataset_info.id.clone(),
         gtfs_rt_urls: dataset_info.gtfs_rt_urls.clone(),
         dataset_actor: dataset_actors_addr.clone(),
     };
@@ -62,6 +64,7 @@ pub fn create_datasets_servers(
             App::with_state(a.clone())
                 .prefix(format!("/{id}", id = &id))
                 .middleware(middleware::Logger::default())
+                .middleware(sentry_actix::SentryMiddleware::new())
                 .middleware(Cors::build().allowed_methods(vec!["GET"]).finish())
                 .resource("/", |r| r.f(status_query))
                 .resource("/gtfs-rt", |r| r.f(gtfs_rt))

--- a/src/tests/update_model_test.rs
+++ b/src/tests/update_model_test.rs
@@ -74,7 +74,7 @@ fn read_simple_gtfs_rt() {
     assert_eq!(
         stu[&2],
         model_update::StopTimeUpdate {
-            stop_point_idx: model.stop_points.get_idx("B").unwrap(),
+            stop_point_idx: model.stop_points.get_idx("B"),
             updated_arrival: Some(ndt("2018-12-15T11:00:30")),
             updated_departure: Some(ndt("2018-12-15T11:01:30")),
         }
@@ -82,7 +82,7 @@ fn read_simple_gtfs_rt() {
     assert_eq!(
         stu[&4],
         model_update::StopTimeUpdate {
-            stop_point_idx: model.stop_points.get_idx("D").unwrap(),
+            stop_point_idx: model.stop_points.get_idx("D"),
             updated_arrival: Some(ndt("2018-12-15T13:00:30")),
             updated_departure: Some(ndt("2018-12-15T13:01:30")),
         }
@@ -161,7 +161,7 @@ fn feed_on_unknown_stop_and_trip() {
     assert_eq!(
         stu[&2],
         model_update::StopTimeUpdate {
-            stop_point_idx: model.stop_points.get_idx("B").unwrap(),
+            stop_point_idx: model.stop_points.get_idx("B"),
             updated_arrival: Some(ndt("2018-12-15T11:00:30")),
             updated_departure: Some(ndt("2018-12-15T11:01:30")),
         }
@@ -169,7 +169,7 @@ fn feed_on_unknown_stop_and_trip() {
     assert_eq!(
         stu[&4],
         model_update::StopTimeUpdate {
-            stop_point_idx: model.stop_points.get_idx("D").unwrap(),
+            stop_point_idx: model.stop_points.get_idx("D"),
             updated_arrival: Some(ndt("2018-12-15T14:00:30")),
             updated_departure: None,
         }


### PR DESCRIPTION
sentry can be activated with the --sentry parameter (or TRANSPO_RT_SENTRY env var)

if activated sentry will now report:

* the 5xx errors
* the gtfs_rt reloading errors
* a warning if some stop_id are incoherent

for the moment for the gtfs_rt problems, we add the dataset id as a tag to the error. we'll need to see if we need more information

some more check will need to be added in the future.

Note: it's after #73 else there is some conflicts