### PR TITLE
add a relaxed way to match a trip 

### DIFF
--- a/src/routes/open_api.rs
+++ b/src/routes/open_api.rs
@@ -196,7 +196,6 @@ fn create_schema() -> oa::Spec {
 }
 
 pub fn documentation(_req: &HttpRequest<Datasets>) -> Json<openapi::v3_0::Spec> {
-    use openapi_schema::OpenapiSchema;
     let mut spec = create_schema();
 
     crate::siri_lite::SiriResponse::generate_schema(&mut spec);


### PR DESCRIPTION
fixes #59

implements the "Alternative trip matching" the [gtfs-rt specification](https://developers.google.com/transit/gtfs-realtime/guides/trip-updates) when we cannot find a corresponding VJ.

Note: with this the [auxerre dataset](https://static.data.gouv.fr/resources/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois/20190605-094228/gtfs.zip) works (`344 connections have been updated with trip updates,`) even if it seems that the GTFS-RT is not completly synced with the GTFS (some routes are missing and some stop_time are not the same)