### PR TITLE
handle errors while reloading base schedule

### DIFF
--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -233,15 +233,19 @@ impl Dataset {
         }
     }
 
-    pub fn from_path(id: &str, gtfs: &str, generation_period: &Period) -> Self {
+    pub fn try_from_path(
+        id: &str,
+        gtfs: &str,
+        generation_period: &Period,
+    ) -> Result<Self, failure::Error> {
         log::info!("reading from path");
         let nav_data = if gtfs.starts_with("http") {
-            transit_model::gtfs::read_from_url(gtfs, None::<&str>, None).unwrap()
+            transit_model::gtfs::read_from_url(gtfs, None::<&str>, None)?
         } else {
-            transit_model::gtfs::read_from_zip(gtfs, None::<&str>, None).unwrap()
+            transit_model::gtfs::read_from_zip(gtfs, None::<&str>, None)?
         };
         log::info!("gtfs read");
-        Self::new(id, nav_data, gtfs, &generation_period)
+        Ok(Self::new(id, nav_data, gtfs, &generation_period))
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,7 +20,9 @@ pub fn create_dataset_actors(
     let logger = slog_scope::logger().new(slog::o!("instance" => dataset_info.id.clone()));
     slog_scope::scope(&logger, || {
         log::info!("creating actors");
-        let dataset = Dataset::from_path(&dataset_info.id, &dataset_info.gtfs, &generation_period);
+        let dataset =
+            Dataset::try_from_path(&dataset_info.id, &dataset_info.gtfs, &generation_period)
+                .unwrap();
         let arc_dataset = Arc::new(dataset);
         let rt_dataset =
             datasets::RealTimeDataset::new(arc_dataset.clone(), &dataset_info.gtfs_rt_urls);


### PR DESCRIPTION
the base schedules are reloading once per day. This operation can fail, if for example the external  erver is temporarily unavailable.

If the reloading fails, we try it again 5mn later, while just keeping the old dataset.

It is not exponential back-off nor do we particularly monitor those fails. If they become more troublesome we could implement more advanced techniques.