### PR TITLE
skipping unknown calendar

### DIFF
--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -138,7 +138,15 @@ fn create_timetable(ntm: &transit_model::Model, generation_period: &Period) -> T
     let end = begin + generation_period.horizon;
 
     for (vj_idx, vj) in ntm.vehicle_journeys.iter() {
-        let service = ntm.calendars.get(&vj.service_id).unwrap();
+        let service =
+            skip_fail!(ntm
+                .calendars
+                .get(&vj.service_id)
+                .ok_or_else(|| failure::format_err!(
+                    "impossible to find service {} for vj {}, skipping vj",
+                    &vj.service_id,
+                    &vj.id
+                )));
         for st in &vj.stop_times {
             for date in service
                 .dates

--- a/src/model_update.rs
+++ b/src/model_update.rs
@@ -148,8 +148,7 @@ fn find_corresponging_vjs(
         .filter(|(vj, _)| {
             // and the trip should start at start_time
             vj.stop_times
-                .iter()
-                .next()
+                .get(0)
                 .map(|st| st.departure_time == start_time)
                 .unwrap_or(false)
         })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ macro_rules! skip_fail {
         match $res {
             Ok(val) => val,
             Err(e) => {
-                warn!("{}", e);
+                log::warn!("{}", e);
                 continue;
             }
         }


### PR DESCRIPTION
in wrongly formatted data, a vehicle journey can be attached to an unknown calendar. We used to stop the program on such case, but now we only skip the vehicle journey.