### PR TITLE
Fix url_for bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
+dependencies = [
+ "quote 1.0.7",
+ "syn 1.0.46",
+]
+
+[[package]]
 name = "debugid"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,6 +1950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,6 +2089,18 @@ name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "difference",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -3645,6 +3676,7 @@ dependencies = [
  "mockito",
  "openapi",
  "openapi-schema",
+ "pretty_assertions",
  "prost 0.6.1",
  "prost-build",
  "prost-derive 0.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ slog-scope-futures = "0.1"
 serde_json = "1.0"
 mockito = "0.15"
 transit_model_builder = "0.1.0"
+pretty_assertions = "0.6"
 
 [build-dependencies]
 prost-build = "0.4"
-

--- a/src/routes/api_entry_point.rs
+++ b/src/routes/api_entry_point.rs
@@ -31,7 +31,7 @@ async fn entry_point(req: HttpRequest, datasets: web::Data<Datasets>) -> web::Js
             })
             .collect(),
         links: btreemap! {
-            "documentation" => Link::from_url(&req, "documentation", &[]),
+            "documentation" => Link::from_url(&req, "documentation"),
             "dataset_detail" => Link {
                 href: raw_url(&req, "/{id}/"),
                 templated: Some(true),

--- a/src/routes/general_message.rs
+++ b/src/routes/general_message.rs
@@ -8,7 +8,7 @@ use crate::siri_lite::{
 use crate::transit_realtime;
 use crate::utils;
 use actix::Addr;
-use actix_web::{get, web, Result};
+use actix_web::{web, Result};
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
@@ -160,7 +160,6 @@ fn general_message(request: Params, rt_data: &RealTimeDataset) -> Result<SiriRes
     })
 }
 
-#[get("/siri/2.0/general-message.json")]
 pub async fn general_message_query(
     web::Query(query): web::Query<Params>,
     dataset_actor: web::Data<Addr<DatasetActor>>,

--- a/src/routes/gtfs_rt.rs
+++ b/src/routes/gtfs_rt.rs
@@ -1,9 +1,8 @@
 use crate::actors::{DatasetActor, GetRealtimeDataset};
 use crate::transit_realtime;
 use actix::Addr;
-use actix_web::{error, get, http::ContentEncoding, web, HttpResponse};
+use actix_web::{error, http::ContentEncoding, web, HttpResponse};
 
-#[get("/gtfs-rt")]
 pub async fn gtfs_rt_protobuf(
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::HttpResponse> {
@@ -24,7 +23,6 @@ pub async fn gtfs_rt_protobuf(
         })
 }
 
-#[get("/gtfs-rt.json")]
 pub async fn gtfs_rt_json(
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<transit_realtime::FeedMessage>> {

--- a/src/routes/links.rs
+++ b/src/routes/links.rs
@@ -25,10 +25,19 @@ pub struct Link {
 }
 
 impl Link {
-    pub fn from_url(req: &actix_web::HttpRequest, name: &str, params: &[&str]) -> Self {
+    pub fn from_url(req: &actix_web::HttpRequest, name: &str) -> Self {
         Self {
             href: req
-                .url_for(name, params)
+                .url_for(name, &[""])
+                .map(|u| u.into_string())
+                .unwrap_or_else(|_| panic!("route {} has not been registered with a name", name)),
+            ..Default::default()
+        }
+    }
+    pub fn from_scoped_url(req: &actix_web::HttpRequest, name: &str, scope: &str) -> Self {
+        Self {
+            href: req
+                .url_for(&format!("{}/{}", scope, name), &[""])
                 .map(|u| u.into_string())
                 .unwrap_or_else(|_| panic!("route {} has not been registered with a name", name)),
             ..Default::default()

--- a/src/routes/status.rs
+++ b/src/routes/status.rs
@@ -1,7 +1,7 @@
 use crate::actors::{DatasetActor, GetDataset};
 use crate::routes::{Link, Links};
 use actix::Addr;
-use actix_web::{get, web, HttpRequest};
+use actix_web::{web, HttpRequest};
 use maplit::btreemap;
 use openapi_schema::OpenapiSchema;
 
@@ -14,7 +14,6 @@ pub struct Status {
     pub links: Links,
 }
 
-#[get("/")]
 pub async fn status_query(
     req: HttpRequest,
     dataset_actor: web::Data<Addr<DatasetActor>>,
@@ -23,23 +22,19 @@ pub async fn status_query(
         log::error!("error while querying actor for data: {:?}", e);
         actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
     })?;
-    let url_for = |link: &str| Link {
-        href: req
-            .url_for(link, &[&dataset.feed_construction_info.dataset_info.id])
-            .map(|u| u.into_string())
-            .unwrap_or_else(|_| panic!("impossible to find route {} to make a link", link)),
-        ..Default::default()
-    };
+
+    let dataset_id = &dataset.feed_construction_info.dataset_info.id;
+
     Ok(web::Json(Status {
         dataset: (&dataset.feed_construction_info.dataset_info).into(),
         loaded_at: dataset.loaded_at,
         links: btreemap! {
-            "gtfs-rt" => url_for("gtfs_rt_protobuf"),
-            "gtfs-rt.json" => url_for("gtfs_rt_json"),
-            "stop-monitoring" => url_for("stop_monitoring_query"),
-            "stoppoints-discovery" => url_for("stoppoints_discovery_query"),
-            "general-message" => url_for("general_message_query"),
-            "siri-lite" => url_for("siri_endpoint"),
+            "gtfs-rt" => Link::from_scoped_url(&req, "gtfs_rt_protobuf", &dataset_id),
+            "gtfs-rt.json" => Link::from_scoped_url(&req, "gtfs_rt_json", &dataset_id),
+            "stop-monitoring" => Link::from_scoped_url(&req, "stop_monitoring_query", &dataset_id),
+            "stoppoints-discovery" => Link::from_scoped_url(&req, "stoppoints_discovery_query", &dataset_id),
+            "general-message" => Link::from_scoped_url(&req, "general_message_query", &dataset_id),
+            "siri-lite" => Link::from_scoped_url(&req, "siri_endpoint", &dataset_id),
         }
         .into(),
     }))

--- a/src/routes/stop_monitoring.rs
+++ b/src/routes/stop_monitoring.rs
@@ -4,7 +4,7 @@ use crate::datasets::{Connection, Dataset, RealTimeConnection, RealTimeDataset, 
 use crate::siri_lite::{self, service_delivery as model, SiriResponse};
 use crate::utils;
 use actix::Addr;
-use actix_web::{error, get, web};
+use actix_web::{error, web};
 use openapi_schema::OpenapiSchema;
 use transit_model::collection::Idx;
 use transit_model::objects::StopPoint;
@@ -227,7 +227,6 @@ fn stop_monitoring(
     })
 }
 
-#[get("/siri/2.0/stop-monitoring.json")]
 pub async fn stop_monitoring_query(
     web::Query(query): web::Query<Params>,
     dataset_actor: web::Data<Addr<DatasetActor>>,

--- a/src/routes/stoppoints_discovery.rs
+++ b/src/routes/stoppoints_discovery.rs
@@ -4,7 +4,7 @@ use crate::siri_lite::shared::CommonDelivery;
 use crate::siri_lite::stop_points_delivery::{AnnotatedStopPoint, StopPointsDelivery};
 use crate::siri_lite::{Siri, SiriResponse};
 use actix::Addr;
-use actix_web::{get, web};
+use actix_web::web;
 
 fn default_limit() -> usize {
     20
@@ -81,7 +81,6 @@ pub fn filter(data: &crate::datasets::Dataset, request: Params) -> SiriResponse 
     }
 }
 
-#[get("/siri/2.0/stoppoints-discovery.json")]
 pub async fn stoppoints_discovery_query(
     web::Query(query): web::Query<Params>,
     dataset_actor: web::Data<Addr<DatasetActor>>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -97,13 +97,41 @@ fn register_dataset_routes(
         cfg.service(
             web::scope(&format!("/{id}", id = &d.id))
                 .data(dataset_actor.clone())
-                .service(status_query)
-                .service(gtfs_rt_protobuf)
-                .service(gtfs_rt_json)
-                .service(siri_endpoint)
-                .service(stoppoints_discovery_query)
-                .service(stop_monitoring_query)
-                .service(general_message_query),
+                .service(
+                    web::resource("/")
+                        .name(&format!("{}/status_query", &d.id))
+                        .route(web::get().to(status_query)),
+                )
+                .service(
+                    web::resource("/gtfs-rt")
+                        .name(&format!("{}/gtfs_rt_protobuf", &d.id))
+                        .route(web::get().to(gtfs_rt_protobuf)),
+                )
+                .service(
+                    web::resource("/gtfs-rt.json")
+                        .name(&format!("{}/gtfs_rt_json", &d.id))
+                        .route(web::get().to(gtfs_rt_json)),
+                )
+                .service(
+                    web::resource("/siri/2.0")
+                        .name(&format!("{}/siri_endpoint", &d.id))
+                        .route(web::get().to(siri_endpoint)),
+                )
+                .service(
+                    web::resource("/siri/2.0/stoppoints-discovery.json")
+                        .name(&format!("{}/stoppoints_discovery_query", &d.id))
+                        .route(web::get().to(stoppoints_discovery_query)),
+                )
+                .service(
+                    web::resource("/siri/2.0/stop-monitoring.json")
+                        .name(&format!("{}/stop_monitoring_query", &d.id))
+                        .route(web::get().to(stop_monitoring_query)),
+                )
+                .service(
+                    web::resource("/siri/2.0/general-message.json")
+                        .name(&format!("{}/general_message_query", &d.id))
+                        .route(web::get().to(general_message_query)),
+                ),
         );
     }
 }


### PR DESCRIPTION
linked to https://github.com/actix/actix-web/issues/1763

There was a bug, all links were linking to the same datasets (because
the routes are scoped).

I don't really see a clean way to make actix handle this, so for the
moment I use a custom name for each route based on the scope
(`{scope}/{route_name}`).

With this we can't use the niiiice `#[get("/routes")]` anymore :sob: