### PR TITLE
fixes trailing slashes handling

### DIFF
--- a/src/routes/links.rs
+++ b/src/routes/links.rs
@@ -35,11 +35,14 @@ impl Link {
         }
     }
     pub fn from_scoped_url(req: &actix_web::HttpRequest, name: &str, scope: &str) -> Self {
+        let route_name = format!("{}/{}", scope, name);
         Self {
             href: req
-                .url_for(&format!("{}/{}", scope, name), &[""])
+                .url_for(&route_name, &[""])
                 .map(|u| u.into_string())
-                .unwrap_or_else(|_| panic!("route {} has not been registered with a name", name)),
+                .unwrap_or_else(|_| {
+                    panic!("route {} has not been registered with a name", route_name)
+                }),
             ..Default::default()
         }
     }

--- a/src/routes/open_api.rs
+++ b/src/routes/open_api.rs
@@ -194,7 +194,7 @@ fn create_schema() -> oa::Spec {
     spec
 }
 
-#[get("/spec")]
+#[get("/spec/")]
 pub async fn documentation() -> web::Json<openapi::v3_0::Spec> {
     let mut spec = create_schema();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -103,32 +103,32 @@ fn register_dataset_routes(
                         .route(web::get().to(status_query)),
                 )
                 .service(
-                    web::resource("/gtfs-rt")
+                    web::resource("/gtfs-rt/")
                         .name(&format!("{}/gtfs_rt_protobuf", &d.id))
                         .route(web::get().to(gtfs_rt_protobuf)),
                 )
                 .service(
-                    web::resource("/gtfs-rt.json")
+                    web::resource("/gtfs-rt.json/")
                         .name(&format!("{}/gtfs_rt_json", &d.id))
                         .route(web::get().to(gtfs_rt_json)),
                 )
                 .service(
-                    web::resource("/siri/2.0")
+                    web::resource("/siri/2.0/")
                         .name(&format!("{}/siri_endpoint", &d.id))
                         .route(web::get().to(siri_endpoint)),
                 )
                 .service(
-                    web::resource("/siri/2.0/stoppoints-discovery.json")
+                    web::resource("/siri/2.0/stoppoints-discovery.json/")
                         .name(&format!("{}/stoppoints_discovery_query", &d.id))
                         .route(web::get().to(stoppoints_discovery_query)),
                 )
                 .service(
-                    web::resource("/siri/2.0/stop-monitoring.json")
+                    web::resource("/siri/2.0/stop-monitoring.json/")
                         .name(&format!("{}/stop_monitoring_query", &d.id))
                         .route(web::get().to(stop_monitoring_query)),
                 )
                 .service(
-                    web::resource("/siri/2.0/general-message.json")
+                    web::resource("/siri/2.0/general-message.json/")
                         .name(&format!("{}/general_message_query", &d.id))
                         .route(web::get().to(general_message_query)),
                 ),

--- a/tests/entry_point_test.rs
+++ b/tests/entry_point_test.rs
@@ -1,6 +1,8 @@
 mod utils;
 use pretty_assertions::assert_eq;
+use serde_json::Value;
 use transpo_rt::datasets::DatasetInfo;
+use utils::get_json;
 
 #[actix_rt::test]
 async fn entry_point_integration_test() {
@@ -13,7 +15,7 @@ async fn entry_point_integration_test() {
 }
 
 async fn test_entrypoint(srv: &mut actix_web::test::TestServer) {
-    let resp: serde_json::Value = utils::get_json(srv, "/").await;
+    let resp: Value = get_json(srv, "/").await;
     assert_eq!(
         resp,
         serde_json::json! {
@@ -24,7 +26,7 @@ async fn test_entrypoint(srv: &mut actix_web::test::TestServer) {
                         "templated": true
                     },
                     "documentation": {
-                        "href": &srv.url("/spec")
+                        "href": &srv.url("/spec/")
                     }
                 },
                 "datasets": [
@@ -46,7 +48,7 @@ async fn test_entrypoint(srv: &mut actix_web::test::TestServer) {
 }
 
 async fn test_dataset_entrypoint(srv: &mut actix_web::test::TestServer) {
-    let mut resp: serde_json::Value = utils::get_json(srv, "/default/").await;
+    let mut resp: Value = get_json(srv, "/default/").await;
 
     // we change the loaded_at datetime to be able to easily compare the response
     *resp.pointer_mut("/loaded_at").unwrap() = "2019-06-20T10:00:00Z".into();
@@ -61,22 +63,22 @@ async fn test_dataset_entrypoint(srv: &mut actix_web::test::TestServer) {
                 "extras": {},
                 "_links": {
                     "general-message": {
-                        "href": &srv.url("/default/siri/2.0/general-message.json")
+                        "href": &srv.url("/default/siri/2.0/general-message.json/")
                     },
                     "gtfs-rt": {
-                        "href": &srv.url("/default/gtfs-rt")
+                        "href": &srv.url("/default/gtfs-rt/")
                     },
                     "gtfs-rt.json": {
-                        "href": &srv.url("/default/gtfs-rt.json")
+                        "href": &srv.url("/default/gtfs-rt.json/")
                     },
                     "stop-monitoring": {
-                        "href": &srv.url("/default/siri/2.0/stop-monitoring.json")
+                        "href": &srv.url("/default/siri/2.0/stop-monitoring.json/")
                     },
                     "siri-lite": {
-                        "href": &srv.url("/default/siri/2.0")
+                        "href": &srv.url("/default/siri/2.0/")
                     },
                     "stoppoints-discovery": {
-                        "href": &srv.url("/default/siri/2.0/stoppoints-discovery.json")
+                        "href": &srv.url("/default/siri/2.0/stoppoints-discovery.json/")
                     }
                 }
             }
@@ -85,7 +87,7 @@ async fn test_dataset_entrypoint(srv: &mut actix_web::test::TestServer) {
 }
 
 async fn test_siri_entrypoint(srv: &mut actix_web::test::TestServer) {
-    let resp: serde_json::Value = utils::get_json(srv, "/default/siri/2.0").await;
+    let resp: Value = get_json(srv, "/default/siri/2.0/").await;
 
     assert_eq!(
         resp,
@@ -93,13 +95,13 @@ async fn test_siri_entrypoint(srv: &mut actix_web::test::TestServer) {
             {
                 "_links": {
                     "general-message": {
-                        "href": &srv.url("/default/siri/2.0/general-message.json")
+                        "href": &srv.url("/default/siri/2.0/general-message.json/")
                     },
                     "stop-monitoring": {
-                        "href": &srv.url("/default/siri/2.0/stop-monitoring.json")
+                        "href": &srv.url("/default/siri/2.0/stop-monitoring.json/")
                     },
                     "stoppoints-discovery": {
-                        "href": &srv.url("/default/siri/2.0/stoppoints-discovery.json")
+                        "href": &srv.url("/default/siri/2.0/stoppoints-discovery.json/")
                     }
                 }
             }
@@ -129,7 +131,7 @@ async fn invalid_dataset_test() {
     ])
     .await;
 
-    let resp: serde_json::Value = utils::get_json(&mut srv, "/").await;
+    let resp: Value = get_json(&mut srv, "/").await;
 
     // there should be only one dataset exposed, the valid one
     assert_eq!(
@@ -167,10 +169,29 @@ async fn multiple_datasets_test() {
 
     check_datasets_entrypoints(&mut srv, &first_dataset).await;
     check_datasets_entrypoints(&mut srv, &second_dataset).await;
+
+    // check that trailing slashes are handled
+    // no particular check on the response is done, we just check that their status are 200
+    get_json::<Value>(&mut srv, "/spec").await;
+    get_json::<Value>(&mut srv, "/spec/").await;
+    get_json::<Value>(&mut srv, "/first_dataset").await;
+    get_json::<Value>(&mut srv, "/first_dataset/").await;
+    get_json::<Value>(&mut srv, "/first_dataset/siri/2.0/").await;
+    get_json::<Value>(&mut srv, "/first_dataset/siri/2.0").await;
+    get_json::<Value>(
+        &mut srv,
+        "/first_dataset/siri/2.0/stoppoints-discovery.json/",
+    )
+    .await;
+    get_json::<Value>(
+        &mut srv,
+        "/first_dataset/siri/2.0/stoppoints-discovery.json",
+    )
+    .await;
 }
 
 async fn check_datasets_entrypoints(srv: &mut actix_web::test::TestServer, dataset: &DatasetInfo) {
-    let mut resp: serde_json::Value = utils::get_json(srv, &format!("/{}/", dataset.id)).await;
+    let mut resp: Value = get_json(srv, &format!("/{}/", dataset.id)).await;
 
     // we change the loaded_at datetime to be able to easily compare the response
     *resp.pointer_mut("/loaded_at").unwrap() = "2019-06-20T10:00:00Z".into();
@@ -185,22 +206,22 @@ async fn check_datasets_entrypoints(srv: &mut actix_web::test::TestServer, datas
                 "extras": {},
                 "_links": {
                     "general-message": {
-                        "href": &srv.url(&format!("/{}/siri/2.0/general-message.json", &dataset.id))
+                        "href": &srv.url(&format!("/{}/siri/2.0/general-message.json/", &dataset.id))
                     },
                     "gtfs-rt": {
-                        "href": &srv.url(&format!("/{}/gtfs-rt", &dataset.id))
+                        "href": &srv.url(&format!("/{}/gtfs-rt/", &dataset.id))
                     },
                     "gtfs-rt.json": {
-                        "href": &srv.url(&format!("/{}/gtfs-rt.json", &dataset.id))
+                        "href": &srv.url(&format!("/{}/gtfs-rt.json/", &dataset.id))
                     },
                     "stop-monitoring": {
-                        "href": &srv.url(&format!("/{}/siri/2.0/stop-monitoring.json", &dataset.id))
+                        "href": &srv.url(&format!("/{}/siri/2.0/stop-monitoring.json/", &dataset.id))
                     },
                     "siri-lite": {
-                        "href": &srv.url(&format!("/{}/siri/2.0", &dataset.id))
+                        "href": &srv.url(&format!("/{}/siri/2.0/", &dataset.id))
                     },
                     "stoppoints-discovery": {
-                        "href": &srv.url(&format!("/{}/siri/2.0/stoppoints-discovery.json", &dataset.id))
+                        "href": &srv.url(&format!("/{}/siri/2.0/stoppoints-discovery.json/", &dataset.id))
                     }
                 }
             }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -30,7 +30,9 @@ pub async fn make_test_server(datasets_info: Vec<DatasetInfo>) -> actix_web::tes
     };
     let actors = transpo_rt::server::create_all_actors(dataset_infos, &period).await;
     actix_web::test::start(move || {
-        actix_web::App::new().configure(|cfg| transpo_rt::server::init_routes(cfg, &actors))
+        actix_web::App::new()
+            .wrap(actix_web::middleware::normalize::NormalizePath::default())
+            .configure(|cfg| transpo_rt::server::init_routes(cfg, &actors))
     })
 }
 


### PR DESCRIPTION
The [actix doc](https://docs.rs/actix-web/3.2.0/actix_web/middleware/normalize/enum.TrailingSlash.html#variant.Always) states that the routes need to be mounted with a trailing slash and since that was not the case some routes were broken