### PR TITLE
Do not unregister datasets with a 404'ed base schedule at time of startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The API provides several routes:
 
 ##### /siri/2.0/stop-monitoring.json
 
-The API follow the [Siri-lite specification](http://www.chouette.mobi/irys/wp-content/uploads/20151023-Siri-Lite-Sp%C3%A9cification-Interfaces-V1.4.pdf) (documentation in french).
+The API follows the [Siri-lite specification](http://www.chouette.mobi/irys/wp-content/uploads/20151023-Siri-Lite-Sp%C3%A9cification-Interfaces-V1.4.pdf) (documentation in french).
 
 A formal description of the supported parameters and of the response can be seen in the [OpenAPI endpoint](https://tr.transport.data.gouv.fr/spec/).
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The API provides several routes:
 * `GET` `/spec`: [OpenApi](https://www.openapis.org/) [v3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md) description of this API - [example call](https://tr.transport.data.gouv.fr/spec)
 * `GET` `/{id}/gtfs-rt`: get the gtfs-rt as binary - [example call](https://tr.transport.data.gouv.fr/horaires-theoriques-du-reseau-tag/gtfs-rt)
 * `GET` `/{id}/gtfs-rt.json`: get the gtfs-rt as json - [example call](https://tr.transport.data.gouv.fr/horaires-theoriques-du-reseau-tag/gtfs-rt.json)
+* `GET` `/{id}/siri/2.0/`: get the list of available siri-lite links [example call](https://tr.transport.data.gouv.fr/horaires-theoriques-du-reseau-tag/siri/2.0)
 * `GET` `/{id}/siri/2.0/stop-monitoring.json`: get a siri-lite stop monitoring response - [example call](https://tr.transport.data.gouv.fr/horaires-theoriques-du-reseau-tag/siri/2.0/stop-monitoring.json?MonitoringRef=4235)
 * `GET` `/{id}/siri/2.0/stoppoints-discovery.json`: get a siri-lite stoppoint discovery response - [example call](https://tr.transport.data.gouv.fr/horaires-theoriques-du-reseau-tag/siri/2.0/stoppoints-discovery.json?q=mairie)
 * `GET` `/{id}/siri/2.0/general-message.json`: get a siri-lite general message response - [example call](https://tr.transport.data.gouv.fr/horaires-theoriques-du-reseau-tag/siri/2.0/general-message.json)

--- a/src/actors/dataset_handler_actor.rs
+++ b/src/actors/dataset_handler_actor.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 ///  * give a pointer to a Dataset (on the GetDataset Message)
 ///  * update the pointer to a new Dataset (on the UpdateBaseSchedule Message)
 pub struct DatasetActor {
-    pub gtfs: Arc<Dataset>,
+    pub gtfs: Arc<Result<Dataset, anyhow::Error>>,
     pub realtime: Arc<RealTimeDataset>,
 }
 
@@ -18,11 +18,11 @@ impl actix::Actor for DatasetActor {
 }
 
 #[derive(actix::Message)]
-#[rtype(result = "Arc<Dataset>")]
+#[rtype(result = "Arc<Result<Dataset, anyhow::Error>>")]
 pub struct GetDataset;
 
 impl actix::Handler<GetDataset> for DatasetActor {
-    type Result = Arc<Dataset>;
+    type Result = Arc<Result<Dataset, anyhow::Error>>;
 
     fn handle(&mut self, _params: GetDataset, _ctx: &mut actix::Context<Self>) -> Self::Result {
         // we return a new Arc on the dataset

--- a/src/actors/realtime_update_actors.rs
+++ b/src/actors/realtime_update_actors.rs
@@ -178,10 +178,10 @@ impl RealTimeReloader {
             .iter()
             .map(|url| fetch_gtfs_rt(&url, &self.log));
 
+        // NOTE: if one of the urls is responding 404, the error is currently logged then ignored
         let gtfs_rts = join_all(gtfs_rts)
             .await
             .into_iter()
-            // TODO : understand what happens if some url is down when the function is called
             .filter_map(|rt| rt.map_err(|e| slog::warn!(self.log, "{}", e)).ok())
             .collect();
 

--- a/src/actors/realtime_update_actors.rs
+++ b/src/actors/realtime_update_actors.rs
@@ -187,7 +187,6 @@ impl RealTimeReloader {
 
         let rt_dataset = self.make_rt_dataset(dataset, gtfs_rts)?;
         // we send those data as a BaseScheduleReloader message, for the DatasetActor to load those new data
-        // TODO warn the actor if we do not have available dataset ?
         self.dataset_actor
             .do_send(UpdateRealtime(Arc::new(rt_dataset)));
         Ok(())

--- a/src/actors/realtime_update_actors.rs
+++ b/src/actors/realtime_update_actors.rs
@@ -144,6 +144,9 @@ impl RealTimeReloader {
             .send(GetDataset)
             .await
             .map_err(|e| anyhow!("maibox error: {}", e))?;
+
+        // TODO: determine how to access the arc content safely, or forward result to call
+
         self.apply_rt(dataset).await
     }
 

--- a/src/actors/realtime_update_actors.rs
+++ b/src/actors/realtime_update_actors.rs
@@ -78,9 +78,9 @@ fn apply_rt_update(
     gtfs_rts: &[transit_realtime::FeedMessage],
     log: &slog::Logger,
 ) -> Result<UpdatedTimetable, Error> {
-    let data = match *data {
+    let data = match &*data {
         // TODO comment
-        Err(e) => return Ok(UpdatedTimetable::default()),
+        Err(_e) => return Ok(UpdatedTimetable::default()),
         Ok(data) => data,
     };
     let mut updated_timetable = UpdatedTimetable::default();
@@ -205,7 +205,7 @@ impl RealTimeReloader {
             .collect();
 
         let gtfs_rt = aggregate_rts(&feed_messages)?;
-        let updated_timetable = apply_rt_update(dataset, &feed_messages, &self.log)?;
+        let updated_timetable = apply_rt_update(dataset.clone(), &feed_messages, &self.log)?;
 
         Ok(RealTimeDataset {
             base_schedule_dataset: dataset,

--- a/src/actors/realtime_update_actors.rs
+++ b/src/actors/realtime_update_actors.rs
@@ -74,12 +74,11 @@ fn aggregate_rts(feed_messages: &[transit_realtime::FeedMessage]) -> Result<Gtfs
 // Since the connection are sorted by scheduled departure time we don't need to reorder the connections, we can update them in place
 // For each trip update, we only have to find the corresponding connection and update it.
 fn apply_rt_update(
-    data: Arc<Result<Dataset, anyhow::Error>>,
+    data: &Arc<Result<Dataset, anyhow::Error>>,
     gtfs_rts: &[transit_realtime::FeedMessage],
     log: &slog::Logger,
 ) -> Result<UpdatedTimetable, Error> {
-    let data = match &*data {
-        // TODO comment
+    let data = match &(**data) {
         Err(_e) => return Ok(UpdatedTimetable::default()),
         Ok(data) => data,
     };
@@ -205,7 +204,7 @@ impl RealTimeReloader {
             .collect();
 
         let gtfs_rt = aggregate_rts(&feed_messages)?;
-        let updated_timetable = apply_rt_update(dataset.clone(), &feed_messages, &self.log)?;
+        let updated_timetable = apply_rt_update(&dataset, &feed_messages, &self.log)?;
 
         Ok(RealTimeDataset {
             base_schedule_dataset: dataset,

--- a/src/actors/update_actors.rs
+++ b/src/actors/update_actors.rs
@@ -27,26 +27,22 @@ impl BaseScheduleReloader {
                 },
             );
 
-            match new_dataset {
-                Err(e) => {
-                    log::warn!("impossible to update dataset because of: {}", e);
-                    log::warn!("rescheduling data loading in 5 mn");
+            if let Err(e) = new_dataset {
+                log::warn!("impossible to update dataset because of: {}", e);
+                log::warn!("rescheduling data loading in 5 mn");
 
-                    // trace error in sentry
-                    sentry::Hub::current().configure_scope(|scope| {
-                        scope.set_tag("dataset", &self.feed_construction_info.dataset_info.id);
-                    });
-                    sentry::integrations::anyhow::capture_anyhow(&e);
+                // trace error in sentry
+                sentry::Hub::current().configure_scope(|scope| {
+                    scope.set_tag("dataset", &self.feed_construction_info.dataset_info.id);
+                });
+                sentry::integrations::anyhow::capture_anyhow(&e);
 
-                    ctx.run_later(std::time::Duration::from_secs(5 * 60), |act, ctx| {
-                        act.update_data(ctx)
-                    });
-                }
-                Ok(d) => {
-                    // we send those data as a BaseScheduleReloader message, for the DatasetActor to load those new data
-                    self.dataset_actor.do_send(UpdateBaseSchedule(Arc::new(d)));
-                }
+                ctx.run_later(std::time::Duration::from_secs(5 * 60), |act, ctx| {
+                    act.update_data(ctx)
+                });
             }
+            self.dataset_actor
+                .do_send(UpdateBaseSchedule(Arc::new(new_dataset)));
         });
     }
 }
@@ -64,7 +60,7 @@ impl actix::Actor for BaseScheduleReloader {
 }
 
 /// Message send to a DatasetActor to update its baseschedule data
-struct UpdateBaseSchedule(Arc<Dataset>);
+struct UpdateBaseSchedule(Arc<Result<Dataset, anyhow::Error>>);
 
 impl actix::Message for UpdateBaseSchedule {
     type Result = ();

--- a/src/actors/update_actors.rs
+++ b/src/actors/update_actors.rs
@@ -27,7 +27,7 @@ impl BaseScheduleReloader {
                 },
             );
 
-            if let Err(e) = new_dataset {
+            if let Err(e) = &new_dataset {
                 log::warn!("impossible to update dataset because of: {}", e);
                 log::warn!("rescheduling data loading in 5 mn");
 

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -80,7 +80,7 @@ pub struct RealTimeDataset {
 }
 
 impl RealTimeDataset {
-    pub fn new(base: Arc<Dataset>, urls: &[String]) -> Self {
+    pub fn new(base: Arc<Result<Dataset, anyhow::Error>>, urls: &[String]) -> Self {
         RealTimeDataset {
             base_schedule_dataset: base,
             gtfs_rt: None,

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -73,7 +73,7 @@ pub struct Dataset {
 
 pub struct RealTimeDataset {
     /// shared ptr to the base schedule dataset
-    pub base_schedule_dataset: Arc<Dataset>,
+    pub base_schedule_dataset: Arc<Result<Dataset, anyhow::Error>>,
     pub gtfs_rt: Option<GtfsRT>,
     pub gtfs_rt_provider_urls: Vec<String>,
     pub updated_timetable: UpdatedTimetable,

--- a/src/routes/general_message.rs
+++ b/src/routes/general_message.rs
@@ -119,9 +119,9 @@ fn read_info_messages(
 }
 
 fn general_message(request: Params, rt_data: &RealTimeDataset) -> Result<SiriResponse> {
-    // TODO: use map_err or a DRY helper
-    let timezone = match *(rt_data.base_schedule_dataset) {
-        Err(e) => return Err(actix_web::error::ErrorBadGateway(e)),
+    let timezone = match &(*rt_data.base_schedule_dataset) {
+        // TODO: figure out how to refer to the original error ("static lifetime required")
+        Err(_) => return Err(actix_web::error::ErrorBadGateway("theoretical dataset temporarily unavailable".to_string())),
         Ok(dataset) => dataset.timezone
     };
 

--- a/src/routes/open_api.rs
+++ b/src/routes/open_api.rs
@@ -155,8 +155,11 @@ fn add_path_item_with_undefined_response(
 }
 
 fn create_schema() -> oa::Spec {
-    let mut spec = oa::Spec::default();
-    spec.openapi = "3.0.0".to_owned();
+    let mut spec = oa::Spec {
+        openapi: "3.0.0".to_owned(),
+        ..Default::default()
+    };
+
     spec.info.title = "Transpo-rt".to_owned();
     spec.info.version = VERSION.to_owned();
     add_route!(spec, "/" => crate::datasets::DatasetInfo, description = "list all the datasets", params = vec![], array = true);

--- a/src/routes/siri.rs
+++ b/src/routes/siri.rs
@@ -9,19 +9,19 @@ pub async fn siri_endpoint(
     req: HttpRequest,
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<Links>> {
-    
-    let result = dataset_actor
-        .send(GetDataset)
-        .await
-        .map_err(|e| {
-            log::error!("error while querying actor for data: {:?}", e);
-            actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-    })?;    
-    
+    let result = dataset_actor.send(GetDataset).await.map_err(|e| {
+        log::error!("error while querying actor for data: {:?}", e);
+        actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
+    })?;
+
     // TODO: discuss this with Antoine to figure out how to do this as a one-liner
     let dataset = match &(*result) {
         Ok(dataset) => dataset,
-        Err(e) => return Err(actix_web::error::ErrorBadGateway("theoretical dataset temporarily unavailable".to_string()))
+        Err(_e) => {
+            return Err(actix_web::error::ErrorBadGateway(
+                "theoretical dataset temporarily unavailable".to_string(),
+            ))
+        }
     };
 
     let dataset_id = &dataset.feed_construction_info.dataset_info.id;

--- a/src/routes/siri.rs
+++ b/src/routes/siri.rs
@@ -9,10 +9,20 @@ pub async fn siri_endpoint(
     req: HttpRequest,
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<Links>> {
-    let dataset = dataset_actor.send(GetDataset).await.map_err(|e| {
-        log::error!("error while querying actor for data: {:?}", e);
-        actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-    })?;
+    let dataset = dataset_actor
+        .send(GetDataset)
+        .await
+        .map_err(|e| {
+            log::error!("error while querying actor for data: {:?}", e);
+            actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
+        })?
+        .map_err(|e| {
+            // TODO : log the error ?
+            actix_web::error::ErrorInternalServerError(
+                "theoretical dataset temporarily unavailable".to_string(),
+            )
+        })?;
+
     let dataset_id = &dataset.feed_construction_info.dataset_info.id;
     Ok(web::Json(
         btreemap! {

--- a/src/routes/siri.rs
+++ b/src/routes/siri.rs
@@ -14,7 +14,6 @@ pub async fn siri_endpoint(
         actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
     })?;
 
-    // TODO: discuss this with Antoine to figure out how to do this as a one-liner
     let dataset = match &(*result) {
         Ok(dataset) => dataset,
         Err(_e) => {

--- a/src/routes/siri.rs
+++ b/src/routes/siri.rs
@@ -9,19 +9,20 @@ pub async fn siri_endpoint(
     req: HttpRequest,
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<Links>> {
-    let dataset = dataset_actor
+    
+    let result = dataset_actor
         .send(GetDataset)
         .await
         .map_err(|e| {
             log::error!("error while querying actor for data: {:?}", e);
             actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-        })?
-        .map_err(|e| {
-            // TODO : log the error ?
-            actix_web::error::ErrorInternalServerError(
-                "theoretical dataset temporarily unavailable".to_string(),
-            )
-        })?;
+    })?;    
+    
+    // TODO: discuss this with Antoine to figure out how to do this as a one-liner
+    let dataset = match &(*result) {
+        Ok(dataset) => dataset,
+        Err(e) => return Err(actix_web::error::ErrorBadGateway("theoretical dataset temporarily unavailable".to_string()))
+    };
 
     let dataset_id = &dataset.feed_construction_info.dataset_info.id;
     Ok(web::Json(

--- a/src/routes/status.rs
+++ b/src/routes/status.rs
@@ -18,17 +18,18 @@ pub async fn status_query(
     req: HttpRequest,
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<Status>> {
-    let result = dataset_actor
-        .send(GetDataset)
-        .await
-        .map_err(|e| {
-            log::error!("error while querying actor for data: {:?}", e);
-            actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-        })?;
+    let result = dataset_actor.send(GetDataset).await.map_err(|e| {
+        log::error!("error while querying actor for data: {:?}", e);
+        actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
+    })?;
 
     let dataset = match &(*result) {
         Ok(dataset) => dataset,
-        Err(e) => return Err(actix_web::error::ErrorBadGateway("theoretical dataset temporarily unavailable".to_string()))
+        Err(_e) => {
+            return Err(actix_web::error::ErrorBadGateway(
+                "theoretical dataset temporarily unavailable".to_string(),
+            ))
+        }
     };
 
     let dataset_id = &dataset.feed_construction_info.dataset_info.id;

--- a/src/routes/status.rs
+++ b/src/routes/status.rs
@@ -18,18 +18,18 @@ pub async fn status_query(
     req: HttpRequest,
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<Status>> {
-    let dataset = dataset_actor
+    let result = dataset_actor
         .send(GetDataset)
         .await
         .map_err(|e| {
             log::error!("error while querying actor for data: {:?}", e);
             actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-        })?
-        .map_err(|e| {
-            actix_web::error::ErrorInternalServerError(
-                "theoretical dataset temporarily unavailable".to_string(),
-            )
         })?;
+
+    let dataset = match &(*result) {
+        Ok(dataset) => dataset,
+        Err(e) => return Err(actix_web::error::ErrorBadGateway("theoretical dataset temporarily unavailable".to_string()))
+    };
 
     let dataset_id = &dataset.feed_construction_info.dataset_info.id;
 

--- a/src/routes/status.rs
+++ b/src/routes/status.rs
@@ -25,10 +25,11 @@ pub async fn status_query(
 
     let dataset = match &(*result) {
         Ok(dataset) => dataset,
-        Err(_e) => {
-            return Err(actix_web::error::ErrorBadGateway(
-                "theoretical dataset temporarily unavailable".to_string(),
-            ))
+        Err(e) => {
+            return Err(actix_web::error::ErrorBadGateway(format!(
+                "theoretical dataset temporarily unavailable : {}",
+                e
+            )))
         }
     };
 

--- a/src/routes/status.rs
+++ b/src/routes/status.rs
@@ -18,10 +18,18 @@ pub async fn status_query(
     req: HttpRequest,
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<Status>> {
-    let dataset = dataset_actor.send(GetDataset).await.map_err(|e| {
-        log::error!("error while querying actor for data: {:?}", e);
-        actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-    })?;
+    let dataset = dataset_actor
+        .send(GetDataset)
+        .await
+        .map_err(|e| {
+            log::error!("error while querying actor for data: {:?}", e);
+            actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
+        })?
+        .map_err(|e| {
+            actix_web::error::ErrorInternalServerError(
+                "theoretical dataset temporarily unavailable".to_string(),
+            )
+        })?;
 
     let dataset_id = &dataset.feed_construction_info.dataset_info.id;
 

--- a/src/routes/stop_monitoring.rs
+++ b/src/routes/stop_monitoring.rs
@@ -195,6 +195,10 @@ fn stop_monitoring(
     rt_data: &RealTimeDataset,
 ) -> actix_web::Result<siri_lite::SiriResponse> {
     let data = &rt_data.base_schedule_dataset;
+    // TODO: support error result by returning an actix error
+    // let data = &rt_data
+    //     .base_schedule_dataset
+    //     .map_err(|e| error::BadGateway(format!("pouet: '{}'", e)))?;
     let updated_timetable = &rt_data.updated_timetable;
 
     validate_params(&mut request)?;

--- a/src/routes/stop_monitoring.rs
+++ b/src/routes/stop_monitoring.rs
@@ -194,15 +194,13 @@ fn stop_monitoring(
     mut request: Params,
     rt_data: &RealTimeDataset,
 ) -> actix_web::Result<siri_lite::SiriResponse> {
-    // TODO: understand exactly why this compiles
-    // let data = *&(rt_data.base_schedule_dataset)
-    //     .map_err(|e| 
-    //         actix_web::error::ErrorBadGateway("theoretical dataset temporarily unavailable".to_string())
-    //         )?;
-    
     let data = match &(*rt_data.base_schedule_dataset) {
         Ok(dataset) => dataset,
-        Err(_) => return Err(actix_web::error::ErrorBadGateway("theoretical dataset temporarily unavailable".to_string()))
+        Err(_) => {
+            return Err(actix_web::error::ErrorBadGateway(
+                "theoretical dataset temporarily unavailable".to_string(),
+            ))
+        }
     };
 
     let updated_timetable = &rt_data.updated_timetable;

--- a/src/routes/stoppoints_discovery.rs
+++ b/src/routes/stoppoints_discovery.rs
@@ -85,18 +85,18 @@ pub async fn stoppoints_discovery_query(
     web::Query(query): web::Query<Params>,
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<SiriResponse>> {
-    let dataset = dataset_actor
+    let result = dataset_actor
         .send(GetDataset)
         .await
         .map_err(|e| {
             log::error!("error while querying actor for data: {:?}", e);
             actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-        })?
-        .map_err(|e| {
-            actix_web::error::ErrorInternalServerError(
-                "theoretical dataset temporarily unavailable".to_string(),
-            )
         })?;
+
+    let dataset = match &(*result) {
+        Ok(dataset) => dataset,
+        Err(e) => return Err(actix_web::error::ErrorBadGateway("theoretical dataset temporarily unavailable".to_string()))
+    };
 
     Ok(web::Json(filter(&dataset, query)))
 }

--- a/src/routes/stoppoints_discovery.rs
+++ b/src/routes/stoppoints_discovery.rs
@@ -85,9 +85,18 @@ pub async fn stoppoints_discovery_query(
     web::Query(query): web::Query<Params>,
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<SiriResponse>> {
-    let dataset = dataset_actor.send(GetDataset).await.map_err(|e| {
-        log::error!("error while querying actor for data: {:?}", e);
-        actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-    })?;
+    let dataset = dataset_actor
+        .send(GetDataset)
+        .await
+        .map_err(|e| {
+            log::error!("error while querying actor for data: {:?}", e);
+            actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
+        })?
+        .map_err(|e| {
+            actix_web::error::ErrorInternalServerError(
+                "theoretical dataset temporarily unavailable".to_string(),
+            )
+        })?;
+
     Ok(web::Json(filter(&dataset, query)))
 }

--- a/src/routes/stoppoints_discovery.rs
+++ b/src/routes/stoppoints_discovery.rs
@@ -85,17 +85,18 @@ pub async fn stoppoints_discovery_query(
     web::Query(query): web::Query<Params>,
     dataset_actor: web::Data<Addr<DatasetActor>>,
 ) -> actix_web::Result<web::Json<SiriResponse>> {
-    let result = dataset_actor
-        .send(GetDataset)
-        .await
-        .map_err(|e| {
-            log::error!("error while querying actor for data: {:?}", e);
-            actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-        })?;
+    let result = dataset_actor.send(GetDataset).await.map_err(|e| {
+        log::error!("error while querying actor for data: {:?}", e);
+        actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
+    })?;
 
     let dataset = match &(*result) {
         Ok(dataset) => dataset,
-        Err(e) => return Err(actix_web::error::ErrorBadGateway("theoretical dataset temporarily unavailable".to_string()))
+        Err(_e) => {
+            return Err(actix_web::error::ErrorBadGateway(
+                "theoretical dataset temporarily unavailable".to_string(),
+            ))
+        }
     };
 
     Ok(web::Json(filter(&dataset, query)))

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,10 +16,8 @@ async fn create_dataset_actors_impl(
     logger: &slog::Logger,
 ) -> (DatasetInfo, Result<Addr<DatasetActor>, anyhow::Error>) {
     log::info!("creating actors");
-    let dataset = match Dataset::try_from_dataset_info(dataset_info.clone(), &generation_period) {
-        Ok(d) => d,
-        Err(e) => return (dataset_info, Err(e)),
-    };
+    let dataset = Dataset::try_from_dataset_info(dataset_info.clone(), &generation_period);
+
     let arc_dataset = Arc::new(dataset);
     let rt_dataset =
         datasets::RealTimeDataset::new(arc_dataset.clone(), &dataset_info.gtfs_rt_urls);

--- a/tests/entry_point_test.rs
+++ b/tests/entry_point_test.rs
@@ -1,4 +1,5 @@
 mod utils;
+use maplit::btreeset;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use transpo_rt::datasets::DatasetInfo;
@@ -115,14 +116,14 @@ async fn invalid_dataset_test() {
     let _log_guard = utils::init_log();
     let mut srv = utils::make_test_server(vec![
         DatasetInfo {
-            id: "valid".into(),
+            id: "a_valid_dataset".into(),
             name: "valid dataset".into(),
             gtfs: "fixtures/gtfs.zip".to_owned(),
             gtfs_rt_urls: [mockito::server_url() + "/gtfs_rt_1"].to_vec(),
             extras: std::collections::BTreeMap::default(),
         },
         DatasetInfo {
-            id: "non_valid".into(),
+            id: "a_non_valid_dataset".into(),
             name: "non valid dataset".into(),
             gtfs: "non_existing_gtfs.zip".to_owned(),
             gtfs_rt_urls: [mockito::server_url() + "/gtfs_rt_1"].to_vec(),
@@ -133,42 +134,17 @@ async fn invalid_dataset_test() {
 
     let resp: Value = get_json(&mut srv, "/").await;
 
-    // there should be only two datasets exposed, the valid one and the non existing
+    // The 2 datasets should be loaded
+    // for the moment the '/' route has no information on the status of the dataset
     assert_eq!(
         resp.get("datasets")
             .and_then(|v| v.as_array())
-            .map(|a| a.len()),
-        Some(2)
+            .expect("should be an array")
+            .iter()
+            .map(|d| d.get("id").unwrap().as_str().unwrap())
+            .collect::<std::collections::BTreeSet<_>>(),
+        btreeset! {"a_valid_dataset", "a_non_valid_dataset"}
     );
-
-    if let Some((valid_dataset_index, non_valid_dataset_index)) =
-        match resp.pointer("/datasets/0/id") {
-            Some(Value::String(v)) if v.eq("valid") => Some((0, 1)),
-            Some(Value::String(v)) if v.eq("non_valid") => Some((1, 0)),
-            _ => None,
-        }
-    {
-        assert_eq!(
-            resp.pointer(&format!("/datasets/{}/id", valid_dataset_index)),
-            Some(&serde_json::json!("valid"))
-        );
-        assert_eq!(
-            resp.pointer(&format!("/datasets/{}/name", valid_dataset_index)),
-            Some(&serde_json::json!("valid dataset"))
-        );
-
-        assert_eq!(
-            resp.pointer(&format!("/datasets/{}/id", non_valid_dataset_index)),
-            Some(&serde_json::json!("non_valid"))
-        );
-        assert_eq!(
-            resp.pointer(&format!("/datasets/{}/name", non_valid_dataset_index)),
-            Some(&serde_json::json!("non valid dataset"))
-        );
-    }
-
-    // TODO ?
-    // let resp: Value = get_json(&mut srv, "/datasets/non_valid").await; //502
     // let resp: Value = get_json(&mut srv, "/datasets/non_valid/gtfs_rt.json").await; // 200
     // let resp: Value = get_json(&mut srv, "/datasets/non_valid/gtfs_rt").await; // 200
     // let resp: Value = get_json(&mut srv, "/datasets/non_valid/siri....").await; // 502

--- a/tests/entry_point_test.rs
+++ b/tests/entry_point_test.rs
@@ -145,9 +145,6 @@ async fn invalid_dataset_test() {
             .collect::<std::collections::BTreeSet<_>>(),
         btreeset! {"a_valid_dataset", "a_non_valid_dataset"}
     );
-    // let resp: Value = get_json(&mut srv, "/datasets/non_valid/gtfs_rt.json").await; // 200
-    // let resp: Value = get_json(&mut srv, "/datasets/non_valid/gtfs_rt").await; // 200
-    // let resp: Value = get_json(&mut srv, "/datasets/non_valid/siri....").await; // 502
 }
 
 #[actix_rt::test]

--- a/tests/gtfs_error_test.rs
+++ b/tests/gtfs_error_test.rs
@@ -7,7 +7,7 @@ async fn start_with_invalid_gtfs_test() {
     let _log_guard = utils::init_log();
 
     let srv = utils::make_test_server(vec![DatasetInfo::new_default(
-        "fixtures/invalid_gtfs.zip",
+        "fixtures/this_file_does_not_exist.zip",
         &[mockito::server_url() + "/gtfs_rt_1"],
     )])
     .await;

--- a/tests/gtfs_error_test.rs
+++ b/tests/gtfs_error_test.rs
@@ -1,14 +1,29 @@
 use actix_web::http::StatusCode;
 use transpo_rt::datasets::DatasetInfo;
+use transpo_rt::transit_realtime;
 mod utils;
+
+fn create_mock_feed_message() -> transit_realtime::FeedMessage {
+    use transpo_rt::transit_realtime::*;
+    FeedMessage {
+        header: FeedHeader {
+            gtfs_realtime_version: "2.0".into(),
+            incrementality: Some(0i32),
+            timestamp: Some(1u64),
+        },
+        entity: vec![],
+    }
+}
 
 #[actix_rt::test]
 async fn start_with_invalid_gtfs_test() {
     let _log_guard = utils::init_log();
 
+    let gtfs_rt = create_mock_feed_message();
+    let _server = utils::run_simple_gtfs_rt_server(gtfs_rt);
     let mut srv = utils::make_test_server(vec![DatasetInfo::new_default(
         "fixtures/this_file_does_not_exist.zip",
-        &[mockito::server_url() + "/gtfs_rt_1"],
+        &[mockito::server_url() + "/gtfs_rt"],
     )])
     .await;
 
@@ -16,14 +31,28 @@ async fn start_with_invalid_gtfs_test() {
         utils::get_status(&mut srv, "/default").await,
         StatusCode::BAD_GATEWAY
     );
-    //assert_eq!(utils::get_status(&mut srv, "/default/gtfs-rt.json").await, StatusCode::OK);
-    //assert_eq!(utils::get_status(&mut srv, "/default/gtfs-rt").await, StatusCode::OK);
     assert_eq!(
-        utils::get_status(&mut srv, "/default/siri/2.0/stop-monitoring.json").await,
+        utils::get_status(&mut srv, "/default/gtfs-rt.json/").await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        utils::get_status(&mut srv, "/default/gtfs-rt").await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        utils::get_status(
+            &mut srv,
+            "/default/siri/2.0/stop-monitoring.json?MonitoringRef=some_code"
+        )
+        .await,
         StatusCode::BAD_GATEWAY
     );
     assert_eq!(
-        utils::get_status(&mut srv, "/default/siri/2.0/stoppoints-discovery.json").await,
+        utils::get_status(
+            &mut srv,
+            "/default/siri/2.0/stoppoints-discovery.json?q=some_query"
+        )
+        .await,
         StatusCode::BAD_GATEWAY
     );
     assert_eq!(

--- a/tests/gtfs_error_test.rs
+++ b/tests/gtfs_error_test.rs
@@ -1,0 +1,17 @@
+use actix_web::http::StatusCode;
+use transpo_rt::datasets::DatasetInfo;
+mod utils;
+
+#[actix_rt::test]
+async fn start_with_invalid_gtfs_test() {
+    let _log_guard = utils::init_log();
+
+    let srv = utils::make_test_server(vec![DatasetInfo::new_default(
+        "fixtures/invalid_gtfs.zip",
+        &[mockito::server_url() + "/gtfs_rt_1"],
+    )])
+    .await;
+
+    let response = srv.get("/default/").send().await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+}

--- a/tests/gtfs_error_test.rs
+++ b/tests/gtfs_error_test.rs
@@ -6,12 +6,28 @@ mod utils;
 async fn start_with_invalid_gtfs_test() {
     let _log_guard = utils::init_log();
 
-    let srv = utils::make_test_server(vec![DatasetInfo::new_default(
+    let mut srv = utils::make_test_server(vec![DatasetInfo::new_default(
         "fixtures/this_file_does_not_exist.zip",
         &[mockito::server_url() + "/gtfs_rt_1"],
     )])
     .await;
 
-    let response = srv.get("/default/").send().await.unwrap();
-    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    assert_eq!(
+        utils::get_status(&mut srv, "/default").await,
+        StatusCode::BAD_GATEWAY
+    );
+    //assert_eq!(utils::get_status(&mut srv, "/default/gtfs-rt.json").await, StatusCode::OK);
+    //assert_eq!(utils::get_status(&mut srv, "/default/gtfs-rt").await, StatusCode::OK);
+    assert_eq!(
+        utils::get_status(&mut srv, "/default/siri/2.0/stop-monitoring.json").await,
+        StatusCode::BAD_GATEWAY
+    );
+    assert_eq!(
+        utils::get_status(&mut srv, "/default/siri/2.0/stoppoints-discovery.json").await,
+        StatusCode::BAD_GATEWAY
+    );
+    assert_eq!(
+        utils::get_status(&mut srv, "/default/siri/2.0/general-message.json").await,
+        StatusCode::BAD_GATEWAY
+    );
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -49,6 +49,14 @@ pub async fn get_json<T: serde::de::DeserializeOwned>(
     response.json().await.unwrap()
 }
 
+#[allow(dead_code)]
+pub async fn get_status(
+    srv: &mut actix_web::test::TestServer,
+    route: &str,
+) -> actix_web::http::StatusCode {
+    srv.get(route).send().await.unwrap().status()
+}
+
 // Note: as each integration test is build as a separate binary,
 // this helper might be seen as dead code for some tests, thus we remove the warning
 #[allow(dead_code)]


### PR DESCRIPTION
As seen in #107, if at start time, a given resource is not available, it will be removed from the available resources forever.

In this PR, we instead implement a mechanism to ensure the initial failure has a chance to recover later.

It must be noted thought that it will currently take 24 hours before the dataset is retried (see #111), something we will improve in a separate PR.