### PR TITLE
Ease way to get RealTimeDataset / Dataset from an actix route

### DIFF
--- a/src/extractors/dataset_wrapper.rs
+++ b/src/extractors/dataset_wrapper.rs
@@ -1,0 +1,123 @@
+use crate::actors::{DatasetActor, GetDataset, GetRealtimeDataset};
+use crate::datasets::{Dataset, RealTimeDataset};
+use actix::Addr;
+use actix_web::{dev::Payload, web::Data, FromRequest, HttpRequest};
+use futures::future::{err, FutureExt, LocalBoxFuture};
+use std::sync::Arc;
+
+/// This wrapper provides a convenient way to get a `Dataset` from an actix route.
+/// It handles all the `DatasetActor` querying and the error handling.
+///
+/// ```
+/// use transpo_rt::extractors::DatasetWrapper;
+/// pub async fn a_route(dataset_wrapper: DatasetWrapper) -> actix_web::Result<()> {
+///    let dataset = dataset_wrapper.get_dataset()?;
+///    Ok(())
+///}
+/// ```
+pub struct DatasetWrapper {
+    dataset: Arc<Result<Dataset, anyhow::Error>>,
+}
+
+/// This wrapper provides a convenient way to get a `RealTimeDataset` from an actix route.
+/// It handles all the `DatasetActor` querying and the error handling.
+///
+/// ```
+/// use transpo_rt::extractors::RealTimeDatasetWrapper;
+/// pub async fn a_route(rt_dataset_wrapper: RealTimeDatasetWrapper) -> actix_web::Result<()> {
+///    let gtfs_rt = &rt_dataset_wrapper.gtfs_rt; // can be used as if it was a RealTimeDataset
+///    let dataset = rt_dataset_wrapper.get_base_schedule_dataset()?;
+///    Ok(())
+///}
+/// ```
+pub struct RealTimeDatasetWrapper {
+    realtime_dataset: Arc<RealTimeDataset>,
+}
+
+impl DatasetWrapper {
+    pub fn get_dataset(&self) -> Result<&Dataset, actix_web::Error> {
+        get_dataset(&self.dataset)
+    }
+}
+
+impl std::ops::Deref for RealTimeDatasetWrapper {
+    type Target = Arc<RealTimeDataset>;
+    fn deref(&self) -> &Self::Target {
+        &self.realtime_dataset
+    }
+}
+
+impl RealTimeDatasetWrapper {
+    pub fn get_base_schedule_dataset(&self) -> Result<&Dataset, actix_web::Error> {
+        get_dataset(&self.realtime_dataset.base_schedule_dataset)
+    }
+}
+
+fn get_dataset(d: &Arc<Result<Dataset, anyhow::Error>>) -> Result<&Dataset, actix_web::Error> {
+    d.as_ref().as_ref().map_err(|e| {
+        actix_web::error::ErrorBadGateway(format!(
+            "theoretical dataset temporarily unavailable: {}",
+            e
+        ))
+    })
+}
+
+impl FromRequest for DatasetWrapper {
+    type Config = ();
+    type Error = actix_web::Error;
+    type Future = LocalBoxFuture<'static, Result<DatasetWrapper, actix_web::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        let dataset_actor = match req.app_data::<Data<Addr<DatasetActor>>>() {
+            Some(d) => d,
+            None => {
+                return err(actix_web::error::ErrorInternalServerError(
+                    "impossible to get data".to_string(),
+                ))
+                .boxed_local()
+            }
+        };
+
+        dataset_actor
+            .send(GetDataset)
+            .map(|res| {
+                res.map_err(|e| {
+                    log::error!("error while querying actor for data: {:?}", e);
+                    actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
+                })
+                .map(|d| DatasetWrapper { dataset: d })
+            })
+            .boxed_local()
+    }
+}
+
+impl FromRequest for RealTimeDatasetWrapper {
+    type Config = ();
+    type Error = actix_web::Error;
+    type Future = LocalBoxFuture<'static, Result<RealTimeDatasetWrapper, actix_web::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        let dataset_actor = match req.app_data::<Data<Addr<DatasetActor>>>() {
+            Some(d) => d,
+            None => {
+                return err(actix_web::error::ErrorInternalServerError(
+                    "impossible to get real time data".to_string(),
+                ))
+                .boxed_local()
+            }
+        };
+
+        dataset_actor
+            .send(GetRealtimeDataset)
+            .map(|res| {
+                res.map_err(|e| {
+                    log::error!("error while querying actor for data: {:?}", e);
+                    actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
+                })
+                .map(|d| RealTimeDatasetWrapper {
+                    realtime_dataset: d,
+                })
+            })
+            .boxed_local()
+    }
+}

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -1,0 +1,3 @@
+mod dataset_wrapper;
+
+pub use dataset_wrapper::{DatasetWrapper, RealTimeDatasetWrapper};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod utils;
 
 pub mod actors;
 pub mod datasets;
+pub mod extractors;
 pub mod middlewares;
 pub(crate) mod model_update;
 pub(crate) mod routes;

--- a/src/routes/gtfs_rt.rs
+++ b/src/routes/gtfs_rt.rs
@@ -1,17 +1,12 @@
-use crate::actors::{DatasetActor, GetRealtimeDataset};
+use crate::extractors::RealTimeDatasetWrapper;
 use crate::transit_realtime;
-use actix::Addr;
 use actix_web::{error, http::ContentEncoding, web, HttpResponse};
 
 pub async fn gtfs_rt_protobuf(
-    dataset_actor: web::Data<Addr<DatasetActor>>,
+    rt_dataset_wrapper: RealTimeDatasetWrapper,
 ) -> actix_web::Result<web::HttpResponse> {
     use actix_web::dev::BodyEncoding;
-    let rt_data = dataset_actor.send(GetRealtimeDataset).await.map_err(|e| {
-        log::error!("error while querying actor for realtime data: {:?}", e);
-        error::ErrorInternalServerError("impossible to get realtime data".to_string())
-    })?;
-    rt_data
+    rt_dataset_wrapper
         .gtfs_rt
         .as_ref()
         .ok_or_else(|| error::ErrorNotFound("no realtime data available"))
@@ -24,15 +19,10 @@ pub async fn gtfs_rt_protobuf(
 }
 
 pub async fn gtfs_rt_json(
-    dataset_actor: web::Data<Addr<DatasetActor>>,
+    rt_dataset_wrapper: RealTimeDatasetWrapper,
 ) -> actix_web::Result<web::Json<transit_realtime::FeedMessage>> {
     use prost::Message;
-
-    let rt_data = dataset_actor.send(GetRealtimeDataset).await.map_err(|e| {
-        log::error!("error while querying actor for realtime data: {:?}", e);
-        error::ErrorInternalServerError("impossible to get realtime data".to_string())
-    })?;
-    rt_data
+    rt_dataset_wrapper
         .gtfs_rt
         .as_ref()
         .ok_or_else(|| error::ErrorNotFound("no realtime data available"))

--- a/src/routes/siri.rs
+++ b/src/routes/siri.rs
@@ -1,28 +1,14 @@
-use crate::actors::{DatasetActor, GetDataset};
+use crate::extractors::DatasetWrapper;
 use crate::routes::{Link, Links};
-use actix::Addr;
 use actix_web::{web, HttpRequest};
 use maplit::btreemap;
 
 /// Api to tell what is available in siri-lite
 pub async fn siri_endpoint(
     req: HttpRequest,
-    dataset_actor: web::Data<Addr<DatasetActor>>,
+    dataset_wrapper: DatasetWrapper,
 ) -> actix_web::Result<web::Json<Links>> {
-    let result = dataset_actor.send(GetDataset).await.map_err(|e| {
-        log::error!("error while querying actor for data: {:?}", e);
-        actix_web::error::ErrorInternalServerError("impossible to get data".to_string())
-    })?;
-
-    let dataset = match &(*result) {
-        Ok(dataset) => dataset,
-        Err(_e) => {
-            return Err(actix_web::error::ErrorBadGateway(
-                "theoretical dataset temporarily unavailable".to_string(),
-            ))
-        }
-    };
-
+    let dataset = dataset_wrapper.get_dataset()?;
     let dataset_id = &dataset.feed_construction_info.dataset_info.id;
     Ok(web::Json(
         btreemap! {


### PR DESCRIPTION
add 2 wrappers that provide a convenient way to get a `RealTimeDataset` / `Dataset` from an actix route.

They handle all the `DatasetActor` querying and the error handling.

```rust
use transpo_rt::extractors::RealTimeDatasetWrapper;
pub async fn a_route(rt_dataset_wrapper: RealTimeDatasetWrapper) -> actix_web::Result<()> {
   let gtfs_rt = &rt_dataset_wrapper.gtfs_rt; // can be used as if it was a RealTimeDataset
   let dataset = rt_dataset_wrapper.get_base_schedule_dataset()?;
   Ok(())
}
```